### PR TITLE
Read host egress

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,23 +20,19 @@ def main():
 
     config.log_config()
 
-    validation_consumer = consume.init_validation_consumer()
-    egress_consumer = consume.init_egress_consumer()
+    consumer = consume.init_consumer()
     global producer
     producer = produce.init_producer()
 
     while True:
-        for data in validation_consumer:
+        for data in consumer:
             try:
-                check_validation(data.value)
+                if data.topic == config.CONSUME_TOPIC:
+                    check_validation(data.value)
+                else:
+                    produce_available(data.value)
             except Exception:
                 logger.exception("An error occurred during message processing")
-
-        for data in egress_consumer:
-            try:
-                produce_available(data.value)
-            except Exception:
-                logger.exception("An error occurred during egress message processing")
 
         producer.flush()
 
@@ -47,11 +43,11 @@ def produce_available(msg):
     logger.debug("Incoming Egress Message Content: %s", msg)
     tracker_msg = msgs.create_msg(msg, "received", "received egress message")
     send_message(config.TRACKER_TOPIC, tracker_msg)
-    platform_metadata = msg.get("platform_metadata")
+    platform_metadata = msg.pop("platform_metadata")
     available_message = {**msg, **platform_metadata}
     logger.debug("Outgoing Egress Message Contents: %s", available_message)
     send_message(config.ANNOUNCER_TOPIC, available_message)
-    tracker_msg = msgs.create_msg(msg, "success", "sent message to %s", config.ANNOUNCER_TOPIC)
+    tracker_msg = msgs.create_msg(msg, "success", "sent message to platform.upload.available")
     send_message(config.TRACKER_TOPIC, tracker_msg)
     logger.info("Sent success message to %s for request %s", config.ANNOUNCER_TOPIC, available_message.get("request_id"))
 
@@ -64,7 +60,7 @@ def check_validation(msg):
     elif msg.get("validation") == "failure":
         try:
             aws.copy(msg.get("request_id"))
-            tracker_msg = msgs.create_msg(msg, "success", "copied failed payload to %s bucket", config.REJECT_BUCKET)
+            tracker_msg = msgs.create_msg(msg, "success", "copied failed payload to reject bucket")
             send_message(config.TRACKER_TOPIC, tracker_msg)
         except ClientError:
             logger.exception("Unable to move %s to %s bucket", config.REJECT_BUCKET, msg.get("request_id"))

--- a/app.py
+++ b/app.py
@@ -20,44 +20,56 @@ def main():
 
     config.log_config()
 
-    consumer = consume.init_consumer()
+    validation_consumer = consume.init_validation_consumer()
+    egress_consumer = consume.init_egress_consumer()
     global producer
     producer = produce.init_producer()
 
     while True:
-        for data in consumer:
+        for data in validation_consumer:
             try:
-                handle_message(data.value)
+                check_validation(data.value)
             except Exception:
                 logger.exception("An error occurred during message processing")
+
+        for data in egress_consumer:
+            try:
+                produce_available(data.value)
+            except Exception:
+                logger.exception("An error occurred during egress message processing")
 
         producer.flush()
 
 
-def handle_message(msg):
+# This is is a way to support legacy uploads that are expected to be on the
+# platform.upload.available queue
+def produce_available(msg):
+    logger.debug("Incoming Egress Message Content: %s", msg)
+    tracker_msg = msgs.create_msg(msg, "received", "received egress message")
+    send_message(config.TRACKER_TOPIC, tracker_msg)
+    platform_metadata = msg.get("platform_metadata")
+    available_message = {**msg, **platform_metadata}
+    logger.debug("Outgoing Egress Message Contents: %s", available_message)
+    send_message(config.ANNOUNCER_TOPIC, available_message)
+    tracker_msg = msgs.create_msg(msg, "success", "sent message to %s", config.ANNOUNCER_TOPIC)
+    send_message(config.TRACKER_TOPIC, tracker_msg)
+    logger.info("Sent success message to %s for request %s", config.ANNOUNCER_TOPIC, available_message.get("request_id"))
+
+
+def check_validation(msg):
     tracker_msg = msgs.create_msg(msg, "received", "received validation response")
     send_message(config.TRACKER_TOPIC, tracker_msg)
     if msg.get("validation") == "success":
-        if msg.get("url") is None:
-            url = aws.get_url(msg.get("request_id"))
-            if url:
-                msg["url"] = url
-        if msg.get("id") is None:
-            msg["id"] = get_inv_id(msg)
-        logger.debug("Message Contents: %s", msg)
-        send_message(config.ANNOUNCER_TOPIC, msg)
-        tracker_msg = msgs.create_msg(msg, "success", "sent message to available topic")
-        send_message(config.TRACKER_TOPIC, tracker_msg)
-        logger.info("Sent success message to %s for request %s", config.ANNOUNCER_TOPIC, msg.get("request_id"))
+        logger.info("Validation success for [%s]", msg.get("request_id"))
     elif msg.get("validation") == "failure":
         try:
             aws.copy(msg.get("request_id"))
-            tracker_msg = msgs.create_msg(msg, "success", "copied rejected payload to rejected bucket")
+            tracker_msg = msgs.create_msg(msg, "success", "copied failed payload to %s bucket", config.REJECT_BUCKET)
             send_message(config.TRACKER_TOPIC, tracker_msg)
         except ClientError:
-            logger.exception("Unable to move %s to rejected bucket", msg.get("request_id"))
+            logger.exception("Unable to move %s to %s bucket", config.REJECT_BUCKET, msg.get("request_id"))
     else:
-        logger.error("Validation key not found or incorrect for %s: [%s]", msg.get("request_id"), msg.get("validation"))
+        logger.error("Validation status not supported: [%s]", msg.get("validation"))
 
 
 def send_message(topic, msg):
@@ -65,20 +77,6 @@ def send_message(topic, msg):
         producer.send(topic=topic, value=msg)
     except KafkaError:
         logger.exception("Unable to topic [%s] for request id [%s]", topic, msg.get("request_id"))
-
-
-def get_inv_id(msg):
-    headers = {"x-rh-identity": msg["b64_identity"]}
-    query_string = "?insights_id={}".format(msg.get("insights_id"))
-    r = requests.get(config.INVENTORY_URL + query_string, headers=headers).json()
-    try:
-        result = r["results"][0]["id"]
-        logger.debug("Got inventory ID successfully for [%s] - [%s]", msg.get("request_id"), result)
-    except (KeyError, IndexError):
-        logger.error("unable to get inventory ID for request: %s", msg["request_id"])
-        result = None
-
-    return result
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -44,6 +44,7 @@ def produce_available(msg):
     tracker_msg = msgs.create_msg(msg, "received", "received egress message")
     send_message(config.TRACKER_TOPIC, tracker_msg)
     platform_metadata = msg.pop("platform_metadata")
+    msg["id"] = msg["host"].get("id")
     available_message = {**msg, **platform_metadata}
     logger.debug("Outgoing Egress Message Contents: %s", available_message)
     send_message(config.ANNOUNCER_TOPIC, available_message)

--- a/mq/consume.py
+++ b/mq/consume.py
@@ -5,8 +5,18 @@ from kafka import KafkaConsumer
 from utils import config
 
 
-def init_consumer():
+def init_validation_consumer():
     consumer = KafkaConsumer(config.CONSUME_TOPIC,
+                             bootstrap_servers=config.BOOTSTRAP_SERVERS,
+                             group_id=config.APP_NAME,
+                             value_deserializer=lambda m: json.loads(m.decode("utf-8")),
+                             retry_backoff_ms=1000,
+                             consumer_timeout_ms=200)
+    return consumer
+
+
+def init_egress_consumer():
+    consumer = KafkaConsumer(config.EGRESS_TOPIC,
                              bootstrap_servers=config.BOOTSTRAP_SERVERS,
                              group_id=config.APP_NAME,
                              value_deserializer=lambda m: json.loads(m.decode("utf-8")),

--- a/mq/consume.py
+++ b/mq/consume.py
@@ -5,18 +5,8 @@ from kafka import KafkaConsumer
 from utils import config
 
 
-def init_validation_consumer():
-    consumer = KafkaConsumer(config.CONSUME_TOPIC,
-                             bootstrap_servers=config.BOOTSTRAP_SERVERS,
-                             group_id=config.APP_NAME,
-                             value_deserializer=lambda m: json.loads(m.decode("utf-8")),
-                             retry_backoff_ms=1000,
-                             consumer_timeout_ms=200)
-    return consumer
-
-
-def init_egress_consumer():
-    consumer = KafkaConsumer(config.EGRESS_TOPIC,
+def init_consumer():
+    consumer = KafkaConsumer(config.CONSUME_TOPIC, config.EGRESS_TOPIC,
                              bootstrap_servers=config.BOOTSTRAP_SERVERS,
                              group_id=config.APP_NAME,
                              value_deserializer=lambda m: json.loads(m.decode("utf-8")),

--- a/utils/config.py
+++ b/utils/config.py
@@ -30,6 +30,7 @@ INVENTORY_URL = os.getenv("INVENTORY_URL", "http://insights-inventory:8080/api/i
 # Kafka
 CONSUME_TOPIC = os.getenv("CONSUME_TOPIC", "platform.upload.validation")
 ANNOUNCER_TOPIC = os.getenv("ANNOUNCER_TOPIC", "platform.upload.available")
+EGRESS_TOPIC = os.getenv("EGRESS_TOPIC", "platform.inventory.host-egress")
 TRACKER_TOPIC = os.getenv("TRACKER_TOPIC", "platform.payload-status")
 BOOTSTRAP_SERVERS = os.getenv("BOOTSTRAP_SERVERS", "kafka:29092").split()
 GROUP_ID = os.getenv("GROUP_ID", APP_NAME)


### PR DESCRIPTION
Instead of taking in the validation message and pointing it to the available topic, we need to grab the inventory egress message. This is because once HBI has handled a payload, it attaches an inventory ID. We need that to go out to the avialable queue. 

We were requesting it before and it was causing a race condition where storage broker could get the message before HBI was done handling it. This meant that we could ask for an inventory ID before one was assigned. By reading host-egress topic, we don't have this issue anymore.