### PR TITLE
Integrate Buck-it use case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bin/
+include/
+lib/
+lib64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM registry.redhat.io/ubi8/python-36
 COPY src src
 COPY setup.py .
+COPY default_map.yaml .
 RUN pip3 install .
 ENTRYPOINT ["storage_broker"]

--- a/default_map.yaml
+++ b/default_map.yaml
@@ -1,0 +1,9 @@
+default:
+  format: "{request_id}"
+  bucket: "insights-upload-rejected"
+openshift:
+  format: "{org_id}/{cluster_id}/{timestamp}-{request_id}"
+  bucket: "insights-buck-it-openshift"
+ansible:
+  format: "{org_id}/{cluster_id}/{timestamp}-{request_id}"
+  bucket: "insights-buck-it-ansible"

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ setup(
         "boto3==1.12.38",
         "watchtower==0.7.3",
         "confluent-kafka==1.3.0",
+        "pyyaml==5.3.1",
+        "attrs==18.2.0",
     ],
     extras_require={"test": ["pytest>=5.4.1", "flake8>=3.7.9"]},
     entry_points={"console_scripts": ["storage_broker = storage_broker.app:main"]},

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "logstash-formatter==0.5.17",
         "boto3==1.12.38",
         "watchtower==0.7.3",
-        "kafka-python==1.4.6",
+        "confluent-kafka==1.3.0",
     ],
     extras_require={"test": ["pytest>=5.4.1", "flake8>=3.7.9"]},
     entry_points={"console_scripts": ["storage_broker = storage_broker.app:main"]},

--- a/src/storage_broker/__init__.py
+++ b/src/storage_broker/__init__.py
@@ -17,16 +17,14 @@ class KeyMap(object):
     account = attr.ib(default=None)
     timestamp = attr.ib(default=None)
     cluster_id = attr.ib(default=None)
-    metadata = attr.ib(default=dict)
     principal = attr.ib(default=None)
-    size = attr.ib(default=None)
-    url = attr.ib(default=None)
     service = attr.ib(default="default")
     b64_identity = attr.ib(default=None)
 
     @classmethod
     def from_json(cls, doc):
         try:
+            doc = {a.name: doc.get(a.name, a.default) for a in attr.fields(KeyMap)}
             return cls(**doc)
         except Exception:
             logger.exception("failed to deserialize message: %s", doc)

--- a/src/storage_broker/__init__.py
+++ b/src/storage_broker/__init__.py
@@ -3,6 +3,7 @@ import json
 import logging
 
 from base64 import b64decode
+from datetime import datetime
 
 from storage_broker.utils import config
 
@@ -25,6 +26,7 @@ class KeyMap(object):
     def from_json(cls, doc):
         try:
             doc = {a.name: doc.get(a.name, a.default) for a in attr.fields(KeyMap)}
+            doc["timestamp"] = datetime.utcnow().strftime("%Y%m%d%H%M%S")
             return cls(**doc)
         except Exception:
             logger.exception("failed to deserialize message: %s", doc)

--- a/src/storage_broker/__init__.py
+++ b/src/storage_broker/__init__.py
@@ -8,6 +8,7 @@ from storage_broker.utils import config
 
 logger = logging.getLogger(config.APP_NAME)
 
+
 @attr.s
 class KeyMap(object):
     org_id = attr.ib(default=None)

--- a/src/storage_broker/__init__.py
+++ b/src/storage_broker/__init__.py
@@ -1,0 +1,35 @@
+import attr
+import json
+import logging
+
+from base64 import b64decode
+
+from storage_broker.utils import config
+
+logger = logging.getLogger(config.APP_NAME)
+
+@attr.s
+class KeyMap(object):
+    org_id = attr.ib(default=None)
+    request_id = attr.ib(default="-1")
+    category = attr.ib(default=None)
+    account = attr.ib(default=None)
+    timestamp = attr.ib(default=None)
+    cluster_id = attr.ib(default=None)
+    metadata = attr.ib(default=dict)
+    principal = attr.ib(default=None)
+    size = attr.ib(default=None)
+    url = attr.ib(default=None)
+    service = attr.ib(default="default")
+    b64_identity = attr.ib(default=None)
+
+    @classmethod
+    def from_json(cls, doc):
+        try:
+            return cls(**doc)
+        except Exception:
+            logger.exception("failed to deserialize message: %s", doc)
+            raise
+
+    def identity(self):
+        return json.loads(b64decode(self.b64_identity))

--- a/src/storage_broker/app.py
+++ b/src/storage_broker/app.py
@@ -46,7 +46,7 @@ def main():
     logger.info("Starting Storage Broker")
 
     config.log_config()
-    
+
     start_prometheus()
 
     consumer = consume.init_consumer()

--- a/src/storage_broker/app.py
+++ b/src/storage_broker/app.py
@@ -11,7 +11,6 @@ from botocore.exceptions import ClientError
 from confluent_kafka import KafkaError
 from prometheus_client import start_http_server
 from functools import partial
-from datetime import datetime
 
 logger = broker_logging.initialize_logging()
 
@@ -111,7 +110,6 @@ def get_key(msg):
     Get the key that will be used when transferring file to the new bucket
     """
     key_map = KeyMap.from_json(msg)
-    key_map.timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
 
     if msg["service"] in BUCKET_MAP.keys():
         service = msg["service"]

--- a/src/storage_broker/default_map.yaml
+++ b/src/storage_broker/default_map.yaml
@@ -1,0 +1,9 @@
+default:
+  format: "{request_id}"
+  bucket: "insights-upload-rejected"
+openshift:
+  format: "{org}/{cluster_id}/{timestamp}-{request_id}"
+  bucket: "insights-buck-it-openshift"
+ansible:
+  format: "{org}/{cluster_id}/{timestamp}-{request_id}"
+  bucket: "insights-buck-it-ansible"

--- a/src/storage_broker/default_map.yaml
+++ b/src/storage_broker/default_map.yaml
@@ -1,9 +1,0 @@
-default:
-  format: "{request_id}"
-  bucket: "insights-upload-rejected"
-openshift:
-  format: "{org}/{cluster_id}/{timestamp}-{request_id}"
-  bucket: "insights-buck-it-openshift"
-ansible:
-  format: "{org}/{cluster_id}/{timestamp}-{request_id}"
-  bucket: "insights-buck-it-ansible"

--- a/src/storage_broker/mq/consume.py
+++ b/src/storage_broker/mq/consume.py
@@ -1,6 +1,6 @@
 from confluent_kafka import Consumer
 
-from ..utils import config
+from storage_broker.utils import config
 
 
 def init_consumer():

--- a/src/storage_broker/mq/consume.py
+++ b/src/storage_broker/mq/consume.py
@@ -1,18 +1,17 @@
-import json
-
-from kafka import KafkaConsumer
+from confluent_kafka import Consumer
 
 from ..utils import config
 
 
 def init_consumer():
-    consumer = KafkaConsumer(
-        config.CONSUME_TOPIC,
-        config.EGRESS_TOPIC,
-        bootstrap_servers=config.BOOTSTRAP_SERVERS,
-        group_id=config.APP_NAME,
-        value_deserializer=lambda m: json.loads(m.decode("utf-8")),
-        retry_backoff_ms=1000,
-        consumer_timeout_ms=200,
+    consumer = Consumer(
+        {
+            "bootstrap.servers": ",".join(config.BOOTSTRAP_SERVERS),
+            "group.id": config.APP_NAME,
+            "queued.max.messages.kbytes": config.KAFKA_QUEUE_MAX_KBYTES,
+            "enable.auto.commit": config.KAFKA_AUTO_COMMIT
+        }
     )
+
+    consumer.subscribe([config.CONSUME_TOPIC, config.EGRESS_TOPIC])
     return consumer

--- a/src/storage_broker/mq/consume.py
+++ b/src/storage_broker/mq/consume.py
@@ -9,7 +9,7 @@ def init_consumer():
             "bootstrap.servers": ",".join(config.BOOTSTRAP_SERVERS),
             "group.id": config.APP_NAME,
             "queued.max.messages.kbytes": config.KAFKA_QUEUE_MAX_KBYTES,
-            "enable.auto.commit": config.KAFKA_AUTO_COMMIT
+            "enable.auto.commit": True,
         }
     )
 

--- a/src/storage_broker/mq/consume.py
+++ b/src/storage_broker/mq/consume.py
@@ -13,5 +13,5 @@ def init_consumer():
         }
     )
 
-    consumer.subscribe([config.CONSUME_TOPIC, config.EGRESS_TOPIC])
+    consumer.subscribe([config.VALIDATION_TOPIC, config.EGRESS_TOPIC, config.STORAGE_TOPIC])
     return consumer

--- a/src/storage_broker/mq/produce.py
+++ b/src/storage_broker/mq/produce.py
@@ -1,6 +1,6 @@
 from confluent_kafka import Producer
 
-from ..utils import config
+from storage_broker.utils import config
 
 
 def init_producer():

--- a/src/storage_broker/mq/produce.py
+++ b/src/storage_broker/mq/produce.py
@@ -1,13 +1,12 @@
-import json
-
-from kafka import KafkaProducer
+from confluent_kafka import Producer
 
 from ..utils import config
 
 
 def init_producer():
-    producer = KafkaProducer(
-        bootstrap_servers=config.BOOTSTRAP_SERVERS,
-        value_serializer=lambda x: json.dumps(x).encode("utf-8"),
+    producer = Producer(
+        {
+            "bootstrap.servers": ",".join(config.BOOTSTRAP_SERVERS),
+        }
     )
     return producer

--- a/src/storage_broker/storage/aws.py
+++ b/src/storage_broker/storage/aws.py
@@ -1,6 +1,8 @@
 import logging
 import boto3
 
+from botocore.exceptions import ClientError
+
 from storage_broker.utils import config
 from storage_broker.utils import metrics
 
@@ -22,6 +24,10 @@ def copy(key, src, dest, new_key):
         s3.delete_object(Bucket=src, Key=key)
         logger.info("Request ID [%s] moved to [%s]", new_key, dest)
         metrics.storage_copy_success.inc()
-    except Exception:
-        logger.exception("Failed to copy Request ID [%s]")
+    except ClientError:
+        logger.exception(
+            "Unable to move %s to %s bucket",
+            key,
+            dest,
+        )
         metrics.storage_copy_error.inc()

--- a/src/storage_broker/storage/aws.py
+++ b/src/storage_broker/storage/aws.py
@@ -2,7 +2,7 @@ import logging
 import boto3
 from botocore.exceptions import ClientError
 
-from ..utils import config
+from storage_broker.utils import config
 
 logger = logging.getLogger(config.APP_NAME)
 

--- a/src/storage_broker/storage/aws.py
+++ b/src/storage_broker/storage/aws.py
@@ -1,6 +1,5 @@
 import logging
 import boto3
-from botocore.exceptions import ClientError
 
 from storage_broker.utils import config
 from storage_broker.utils import metrics
@@ -26,18 +25,3 @@ def copy(key, src, dest, new_key):
     except Exception:
         logger.exception("Failed to copy Request ID [%s]")
         metrics.storage_copy_error.inc()
-
-
-def get_url(key, src):
-    try:
-        response = s3.generate_presigned_url(
-            "get_object",
-            Params={"Bucket": src, "Key": key},
-            ExpiresIn=86400,
-        )
-        logger.debug(response)
-    except ClientError:
-        logger.error("Failed to get url for %s", key)
-        return None
-
-    return response

--- a/src/storage_broker/storage/aws.py
+++ b/src/storage_broker/storage/aws.py
@@ -14,19 +14,19 @@ s3 = boto3.client(
 )
 
 
-def copy(key):
-    copy_src = {"Bucket": config.STAGE_BUCKET, "Key": key}
+def copy(key, src, dest, new_key):
+    copy_src = {"Bucket": src, "Key": key}
 
-    s3.copy(copy_src, config.REJECT_BUCKET, key)
-    s3.delete_object(Bucket=config.STAGE_BUCKET, Key=key)
-    logger.info("Request ID [%s] moved to [%s]", key, config.REJECT_BUCKET)
+    s3.copy(copy_src, dest, new_key)
+    s3.delete_object(Bucket=src, Key=key)
+    logger.info("Request ID [%s] moved to [%s]", new_key, dest)
 
 
-def get_url(key):
+def get_url(key, src):
     try:
         response = s3.generate_presigned_url(
             "get_object",
-            Params={"Bucket": config.STAGE_BUCKET, "Key": key},
+            Params={"Bucket": src, "Key": key},
             ExpiresIn=86400,
         )
         logger.debug(response)

--- a/src/storage_broker/utils/broker_logging.py
+++ b/src/storage_broker/utils/broker_logging.py
@@ -7,7 +7,7 @@ import watchtower
 from logstash_formatter import LogstashFormatterV1
 from boto3.session import Session
 
-from ..utils import config
+from storage_broker.utils import config
 
 
 def config_cloudwatch(logger):

--- a/src/storage_broker/utils/config.py
+++ b/src/storage_broker/utils/config.py
@@ -51,3 +51,6 @@ CW_AWS_SECRET_ACCESS_KEY = os.getenv("CW_AWS_SECRET_ACCESS_KEY", None)
 LOG_GROUP = os.getenv("LOG_GROUP", "platform-dev")
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 NAMESPACE = get_namespace()
+
+# Metrics
+PROMETHEUS_PORT = os.getenv("PROMETHEUS_PORT", 8080)

--- a/src/storage_broker/utils/config.py
+++ b/src/storage_broker/utils/config.py
@@ -28,8 +28,9 @@ def get_namespace():
 INVENTORY_URL = os.getenv("INVENTORY_URL", "http://insights-inventory:8080/api/inventory/v1/hosts")
 
 # Kafka
-CONSUME_TOPIC = os.getenv("CONSUME_TOPIC", "platform.upload.validation")
+VALIDATION_TOPIC = os.getenv("CONSUME_TOPIC", "platform.upload.validation")
 ANNOUNCER_TOPIC = os.getenv("ANNOUNCER_TOPIC", "platform.upload.available")
+STORAGE_TOPIC = os.getenv("STORAGE_TOPIC", "platform.upload.buckit")
 EGRESS_TOPIC = os.getenv("EGRESS_TOPIC", "platform.inventory.host-egress")
 TRACKER_TOPIC = os.getenv("TRACKER_TOPIC", "platform.payload-status")
 BOOTSTRAP_SERVERS = os.getenv("BOOTSTRAP_SERVERS", "kafka:29092").split()
@@ -44,6 +45,7 @@ AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
 STAGE_BUCKET = os.getenv("STAGE_BUCKET", "insights-dev-upload-perm")
 REJECT_BUCKET = os.getenv("REJECT_BUCKET", "insights-dev-upload-rejected")
 S3_ENDPOINT_URL = os.getenv("S3_ENDPOINT_URL", None)
+BUCKET_MAP_FILE = os.getenv("BUCKET_MAP_FILE", "/opt/app-root/src/default_map.yaml")
 
 # Logging
 CW_AWS_ACCESS_KEY_ID = os.getenv("CW_AWS_ACCESS_KEY_ID", None)

--- a/src/storage_broker/utils/config.py
+++ b/src/storage_broker/utils/config.py
@@ -36,7 +36,6 @@ TRACKER_TOPIC = os.getenv("TRACKER_TOPIC", "platform.payload-status")
 BOOTSTRAP_SERVERS = os.getenv("BOOTSTRAP_SERVERS", "kafka:29092").split()
 GROUP_ID = os.getenv("GROUP_ID", APP_NAME)
 KAFKA_QUEUE_MAX_KBYTES = os.getenv("KAFKA_QUEUE_MAX_KBYTES", 1024)
-KAFKA_AUTO_COMMIT = os.getenv("KAFKA_AUTO_COMMIT", False)
 
 # S3
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", None)

--- a/src/storage_broker/utils/config.py
+++ b/src/storage_broker/utils/config.py
@@ -34,6 +34,8 @@ EGRESS_TOPIC = os.getenv("EGRESS_TOPIC", "platform.inventory.host-egress")
 TRACKER_TOPIC = os.getenv("TRACKER_TOPIC", "platform.payload-status")
 BOOTSTRAP_SERVERS = os.getenv("BOOTSTRAP_SERVERS", "kafka:29092").split()
 GROUP_ID = os.getenv("GROUP_ID", APP_NAME)
+KAFKA_QUEUE_MAX_KBYTES = os.getenv("KAFKA_QUEUE_MAX_KBYTES", 1024)
+KAFKA_AUTO_COMMIT = os.getenv("KAFKA_AUTO_COMMIT", False)
 
 # S3
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", None)

--- a/src/storage_broker/utils/metrics.py
+++ b/src/storage_broker/utils/metrics.py
@@ -1,4 +1,4 @@
-from prometheus_client import Summary, Counter
+from prometheus_client import Histogram, Counter
 
 # Counters
 message_consume_error_count = Counter("storage_broker_message_consume_error_count", "Total consumption errors in consumer")
@@ -12,5 +12,5 @@ invalid_validation_status = Counter("storage_broker_invalid_status_count", "Tota
 
 
 # Summaries
-get_key_time = Summary("storage_broker_get_key_function_time_seconds", "Total time to get the key and bucket destination for payload")
-storage_copy_time = Summary("storage_broker_object_copy_time_seconds", "Total time it takes to copy an object from one bucket to another")
+get_key_time = Histogram("storage_broker_get_key_function_time_seconds", "Total time to get the key and bucket destination for payload")
+storage_copy_time = Histogram("storage_broker_object_copy_time_seconds", "Total time it takes to copy an object from one bucket to another")

--- a/src/storage_broker/utils/metrics.py
+++ b/src/storage_broker/utils/metrics.py
@@ -1,0 +1,16 @@
+from prometheus_client import Summary, Counter
+
+# Counters
+message_consume_error_count = Counter("storage_broker_message_consume_error_count", "Total consumption errors in consumer")
+message_consume_count = Counter("storage_broker_message_consume_count", "Total count of consumed messages")
+message_publish_count = Counter("storage_broker_message_publish_count", "Total messages published on kafka")
+message_publish_error = Counter("storage_broker_message_publish_error_count", "Total messages that failed to publish")
+message_json_unpack_error = Counter("storage_broker_message_json_upack_error_count", "Total message with bad json")
+storage_copy_error = Counter("storage_broker_object_copy_error_count", "Total errors encountered by the copy operation")
+storage_copy_success = Counter("storage_broker_object_copy_success_count", "Total successful object moves")
+invalid_validation_status = Counter("storage_broker_invalid_status_count", "Total invalid status messages received")
+
+
+# Summaries
+get_key_time = Summary("storage_broker_get_key_function_time_seconds", "Total time to get the key and bucket destination for payload")
+storage_copy_time = Summary("storage_broker_object_copy_time_seconds", "Total time it takes to copy an object from one bucket to another")


### PR DESCRIPTION
With storage-broker, we can remove the need for the buck-it service by just taking over the copy process that it does. This is the first pass on making storage-broker the gatekeeper for our cloud storage allowing more services to simply use it to store whatever payloads they'd like in the bucket of their choice.