### PR TITLE
fix: support arbitrary bucket secret

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -62,6 +62,18 @@ objects:
             value: ${REJECT_BUCKET}
           - name: BUCKET_MAP_FILE
             value: ${BUCKET_MAP_FILE}
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                optional: true
+                name: ${POLICY_BASED_KEY}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                optional: true
+                name: ${POLICY_BASED_KEY}
+                key: aws_secret_access_key
     objectStore:
       - ${PERM_BUCKET}
       - ${REJECT_BUCKET}
@@ -144,3 +156,6 @@ parameters:
 - description: bucket config map location
   name: BUCKET_MAP_FILE
   value: "/var/config.yaml"
+- description: policy based key
+  name: POLICY_BASED_KEY
+  value: "insights-buckets-read-write"

--- a/src/storage_broker/utils/config.py
+++ b/src/storage_broker/utils/config.py
@@ -60,13 +60,16 @@ if os.getenv("CLOWDER_ENABLED") == "true":
     AWS_SECRET_ACCESS_KEY = cfg.objectStore.secretKey
     STAGE_BUCKET = ObjectBuckets[os.environ.get("PERM_BUCKET")].name
     REJECT_BUCKET = ObjectBuckets[os.environ.get("REJECT_BUCKET")].name
-    
 else:    
     AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", None)
     AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", None)
     STAGE_BUCKET = os.getenv("STAGE_BUCKET", "insights-dev-upload-perm")
     REJECT_BUCKET = os.getenv("REJECT_BUCKET", "insights-dev-upload-rejected")
-    
+
+# We need to support local or policy based keys that don't work with clowder
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", AWS_ACCESS_KEY_ID)
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", AWS_SECRET_ACCESS_KEY)
+
 AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
 S3_ENDPOINT_URL = os.getenv("S3_ENDPOINT_URL", None)
 BUCKET_MAP_FILE = os.getenv("BUCKET_MAP_FILE", "/opt/app-root/src/default_map.yaml")


### PR DESCRIPTION
We have a policy that defines an IAM secret in clowder, and we need
storage broker to be able to consume and use that secret

Signed-off-by: Stephen Adams <tsadams@gmail.com>