### PR TITLE
fix: catch more exceptions on copy errors

### DIFF
--- a/src/storage_broker/storage/aws.py
+++ b/src/storage_broker/storage/aws.py
@@ -1,8 +1,6 @@
 import logging
 import boto3
 
-from botocore.exceptions import ClientError
-
 from storage_broker.utils import config
 from storage_broker.utils import metrics
 
@@ -24,6 +22,6 @@ def copy(key, src, dest, new_key, size, service):
         s3.copy(copy_src, dest, new_key)
         logger.info("Request ID [%s] moved to [%s]", new_key, dest)
         metrics.storage_copy_success.labels(bucket=dest).inc()
-    except ClientError:
+    except Exception:
         logger.exception("Unable to move %s to %s bucket", key, dest)
         metrics.storage_copy_error.labels(bucket=dest).inc()


### PR DESCRIPTION
We had this narrowed down to only ClientErrors from botocore, but we
need to catch all types of errors that could potentially be an issue
related to the client.

Signed-off-by: Stephen Adams <tsadams@gmail.com>