### PR TITLE
[DO NOT MERGE] task(msgs): add org_id to messages

### DIFF
--- a/src/storage_broker/__init__.py
+++ b/src/storage_broker/__init__.py
@@ -13,6 +13,7 @@ class TrackerMessage(object):
     def __init__(self, data):
         self.service = "storage-broker"
         self.account = data.get("account")
+        self.org_id = data.get("org_id")
         self.request_id = data.get("request_id", str(uuid.uuid4().hex))
         if data.get("host"):
             self.inventory_id = data.get("id")

--- a/src/storage_broker/normalizers.py
+++ b/src/storage_broker/normalizers.py
@@ -9,6 +9,11 @@ from base64 import b64decode
 logger = logging.getLogger(__name__)
 
 
+def parse_identity(b64_identity):
+    ident = json.loads(b64decode(b64_identity).decode("utf-8"))
+    return ident
+
+
 @attr.s
 class Validation(object):
     """
@@ -20,19 +25,29 @@ class Validation(object):
     request_id = attr.ib(default=str(uuid.uuid4().hex))
     reason = attr.ib(default=None)
     account = attr.ib(default=None)
+    org_id = attr.ib(default=None)
     reporter = attr.ib(default=None)
     system_id = attr.ib(default=None)
     hostname = attr.ib(default=None)
     size = attr.ib(default=None)
 
+
     @classmethod
     def from_json(cls, doc):
         try:
+            # default dictionary in case we don't have an identity
+            ident = {"identity": {"account": None,
+                                  "internal": {"org_id": None}
+                                  }
+                     }
+            if doc.get("b64_identity"):
+                ident = parse_identity(doc["b64_identity"])
             validation = doc["validation"]
             service = doc.get("service")
             request_id = doc.get("request_id", str(uuid.uuid4().hex))
             reason = doc.get("reason")
-            account = doc.get("account")
+            account = doc.get("account") if doc.get("account") else ident["identity"]["account_number"]
+            org_id = doc.get("org_id") if doc.get("org_id") else ident["identity"]["internal"]["org_id"]
             reporter = doc.get("reporter")
             system_id = doc.get("system_id")
             hostname = doc.get("hostname")
@@ -40,7 +55,7 @@ class Validation(object):
             return cls(
                 validation=validation, service=service, request_id=request_id,
                 reason=reason, reporter=reporter, system_id=system_id,
-                hostname=hostname, account=account, size=size
+                hostname=hostname, account=account, org_id=org_id, size=size
             )
         except Exception:
             logger.exception("Unable to deserialize JSON: %s", doc)
@@ -60,7 +75,7 @@ class Openshift(object):
     @classmethod
     def from_json(cls, doc):
         try:
-            ident = json.loads(b64decode(doc["b64_identity"]).decode("utf-8"))
+            ident = parse_identity(doc["b64_identity"])
             if ident["identity"].get("system"):
                 cluster_id = ident["identity"]["system"].get("cluster_id")
             org_id = ident["identity"]["internal"].get("org_id")

--- a/src/storage_broker/normalizers.py
+++ b/src/storage_broker/normalizers.py
@@ -37,7 +37,7 @@ class Validation(object):
         try:
             # default dictionary in case we don't have an identity
             ident = {"identity": {"account": None,
-                                  "internal": {"org_id": None}
+                                  "org_id": None
                                   }
                      }
             if doc.get("b64_identity"):
@@ -47,7 +47,7 @@ class Validation(object):
             request_id = doc.get("request_id", str(uuid.uuid4().hex))
             reason = doc.get("reason")
             account = doc.get("account") if doc.get("account") else ident["identity"]["account_number"]
-            org_id = doc.get("org_id") if doc.get("org_id") else ident["identity"]["internal"]["org_id"]
+            org_id = doc.get("org_id") if doc.get("org_id") else ident["identity"]["org_id"]
             reporter = doc.get("reporter")
             system_id = doc.get("system_id")
             hostname = doc.get("hostname")
@@ -78,7 +78,7 @@ class Openshift(object):
             ident = parse_identity(doc["b64_identity"])
             if ident["identity"].get("system"):
                 cluster_id = ident["identity"]["system"].get("cluster_id")
-            org_id = ident["identity"]["internal"].get("org_id")
+            org_id = ident["identity"].get("org_id")
             account = ident["identity"]["account_number"]
             service = doc["service"]
             request_id = doc.get("request_id", str(uuid.uuid4().hex))

--- a/tests/test_msgs.py
+++ b/tests/test_msgs.py
@@ -7,6 +7,7 @@ from storage_broker.normalizers import Validation
 
 MSG = {
     "account": "000001",
+    "org_id": "123456",
     "reporter": "puptoo",
     "request_id": "12345",
     "system_id": "abdc-1234",
@@ -22,6 +23,7 @@ def test_validation_normalizer():
     normalizer = Validation()
     data = normalizer.from_json(MSG)
     assert data.account == "000001"
+    assert data.org_id == "123456"
 
 
 def test_notification_msg():
@@ -30,9 +32,9 @@ def test_notification_msg():
     msg = notification_msg(data)
     assert type(msg["events"][0]["payload"]) == str
     assert msg["version"] == "v1.1.0"
-    assert msg["bundle"] == "rhel"
-    assert msg["application"] == "validation"
-    assert msg["event_type"] == "upload_rejection"
+    assert msg["bundle"] == "console"
+    assert msg["application"] == "storage-broker"
+    assert msg["event_type"] == "upload-rejection"
     assert msg["account"] == "000001"
     assert msg["events"][0]["metadata"] == {}
 


### PR DESCRIPTION
Moving to org_id for tracking and handling payloads. This change sets up
storage broker to be able to receive and pass along org_ids.

RHCLOUD-17861


## What?
The org_id is going to be used to manage uploads in the near future. This change adds org_id to any incoming and outgoing messages:

RHCLOUD-17861

## Why?
Direction from the BU

## How?
Added org_id to the dictionaries associated with payload_tracker messages and ensured that it is pulled from incoming validation messages.
It has a fallback feature so that if it is not pulled from incoming messages, we dig into the base64 identity header to get it.

## Testing
Updated messages testing for this change.

## Anything Else?
I put in a default dictionary for identity mainly for local use and testing. IN production, there should never be an occasion where we don't have
org_id directly in the message or in the base64 identity header at the very least.

I'm open to suggestions if there is a smarter way to handle that. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices