### PR TITLE
fix: look for org-id in two places

### DIFF
--- a/src/storage_broker/app.py
+++ b/src/storage_broker/app.py
@@ -155,6 +155,7 @@ def main():
 def normalize(_map, decoded_msg):
     normalizer = getattr(normalizers, _map["normalizer"])
     data = normalizer.from_json(decoded_msg)
+    logger.debug("Normalized Data structure: %s", data)
     return data
 
 

--- a/src/storage_broker/normalizers.py
+++ b/src/storage_broker/normalizers.py
@@ -37,11 +37,16 @@ class Validation(object):
         try:
             # default dictionary in case we don't have an identity
             ident = {"identity": {"account": None,
-                                  "org_id": None
+                                  "org_id": None,
+                                  "internal": {
+                                      "org_id": None,
+                                      }
                                   }
                      }
             if doc.get("b64_identity"):
                 ident = parse_identity(doc["b64_identity"])
+            if not ident["identity"].get("org_id") and ident["identity"]["internal"].get("org_id"):
+                ident["identity"]["org_id"] == ident["identity"]["internal"]["org_id"]
             validation = doc["validation"]
             service = doc.get("service")
             request_id = doc.get("request_id", str(uuid.uuid4().hex))
@@ -78,7 +83,9 @@ class Openshift(object):
             ident = parse_identity(doc["b64_identity"])
             if ident["identity"].get("system"):
                 cluster_id = ident["identity"]["system"].get("cluster_id")
-            org_id = ident["identity"].get("org_id")
+            if not ident["identity"].get("org_id") and ident["identity"]["internal"].get("org_id"):
+                ident["identity"]["org_id"] = ident["identity"]["internal"]["org_id"]
+            org_id = ident["identity"]["org_id"]
             account = ident["identity"]["account_number"]
             service = doc["service"]
             request_id = doc.get("request_id", str(uuid.uuid4().hex))


### PR DESCRIPTION
We want to make sure we populate an org-id, so we need to cover for
messages where the org-id is still in the `internal` key

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Pull the org_id from the root of the identity if it's there, otherwise, get it out of the internal key like we always have

## Why?
The org_id could be in either of those two places and we ought to account for that.

## How?
Modify our class to check for either one.

## Testing
Local testing

## Anything Else?
We blew up CCX with the previous commit so this is the attempt to swing back around and make sure we don't break anything else.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
