### PR TITLE
Adding openapi spec for storage broker API

### DIFF
--- a/schema/sb.openapi.yaml
+++ b/schema/sb.openapi.yaml
@@ -1,0 +1,72 @@
+---
+openapi: 3.0.3
+info:
+  title: Storage Broker API
+  description: Storage Broker API returns url to download AWS archive
+  version: 1.0.0
+
+paths:
+  /archive/fetch:
+    get:
+      summary: Returns archive download url
+      description: Fetches an archive download url from AWS.
+      operationId: api.archive.fetch
+      parameters:
+      - $ref: '#/components/parameters/requestId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArchiveInfo'
+        '400':
+          description: '#/components/responses/BadRequest'
+
+components:
+  schemas:
+    ArchiveInfo:
+      type: object
+      properties:
+        request_id:
+          $ref: '#/components/schemas/RequestId'
+        url:
+          $ref: '#/components/schemas/Url'
+      required:
+      - request_id
+      - url
+
+    RequestId:
+      description: The request id of a payload.
+      type: string
+      format: uuid
+
+    Url:
+      description: AWS archive download url for a payload.
+      type: string
+      format: url
+
+    Error:
+      type: object
+      properties:
+        message:
+          type: string
+          description: Error message
+      required:
+      - message
+
+  parameters:
+    requestId:
+      in: query
+      name: request_id
+      required: true
+      schema:
+        $ref: '#/components/schemas/RequestId'
+
+  responses:
+    BadRequest:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'


### PR DESCRIPTION
## What?
Adding an OpenAPI specification for the upcoming Storage Broker API.
Part of [RHCLOUD-18663](https://issues.redhat.com/browse/RHCLOUD-18663).

I wanted to go with the new OpenAPI spec version `3.1.0`, but decided to stick with `3.0.3` as this version has wider support.

## Why?
It will make it easier to build and interact with the API.

## How?
Added OpenAPI spec yaml file.

## Testing
Not applicable.

## Anything Else?
You can get a sense of the API interface by going to the [Swagger Editor](https://editor.swagger.io/#) and copy-pasting the spec file.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
