### PR TITLE
Add presigned url generation for API [RHCLOUD-18663]

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,25 @@ storage_broker_api
 make produce_validation_message
 ```
 
+### Local AWS S3 interaction testing using Minio
+
+You can test the AWS interaction of storage broker using Minio.
+To do so, you will need to set the following environment variables to the storage broker consumer or API.
+
+```
+S3_ENDPOINT_URL=<minio_api_endpoint/>
+AWS_ACCESS_KEY_ID=<minio_access_key_id/>
+AWS_SECRET_ACCESS_KEY=<minio_secret_access_key/>
+STAGE_BUCKET=<bucket_name/>
+```
+
+For example
+```
+AWS_ACCESS_KEY_ID=$MINIO_ACCESS_KEY AWS_SECRET_ACCESS_KEY=$MINIO_SECRET_KEY S3_ENDPOINT_URL=minio_api_endpoint:9000 STAGE_BUCKET=insights-dev-upload-perm storage_brokerer_api
+```
+
+Local Minio access keys are provided [here](https://github.com/RedHatInsights/insights-storage-broker/blob/master/.env).
+
 ## Authors
 
 Stephen Adams - Initial Work - [SteveHNH](https://www.github.com/SteveHNH)

--- a/schema/sb.openapi.yaml
+++ b/schema/sb.openapi.yaml
@@ -50,9 +50,10 @@ components:
       format: url
 
     Timeout:
-      description: AWS download url timeout.
+      description: AWS download url timeout in iso format date-time string.
       type: string
       format: date-time
+      example: "2022-04-19T21:54:57+00:00"
 
     Error:
       type: object

--- a/src/storage_broker/api/__init__.py
+++ b/src/storage_broker/api/__init__.py
@@ -25,7 +25,7 @@ def get_archive_url():
 
     url = aws.get_url(config.STAGE_BUCKET, request_id, config.API_URL_EXPIRY)
     if not url:
-        return error_message('payload for the request_id may not be available'), 400
+        return error_message('aws client error'), 500
 
     timeout = datetime.utcnow() + timedelta(seconds=config.API_URL_EXPIRY)
     timeout_str = str(timeout.replace(microsecond=0, tzinfo=timezone.utc).isoformat())

--- a/src/storage_broker/api/__init__.py
+++ b/src/storage_broker/api/__init__.py
@@ -1,10 +1,16 @@
+from socket import timeout
+from time import time
 import uuid
+from datetime import datetime, timezone, timedelta
 from flask import Flask, request, jsonify
 
+from src.storage_broker.storage import aws
 from src.storage_broker.utils import broker_logging, config
+
 
 app = Flask(__name__)
 logger = broker_logging.initialize_logging()
+
 
 @app.route("/archive/url/", methods=['GET'])
 def get_archive_url():    
@@ -17,7 +23,13 @@ def get_archive_url():
     except ValueError:
         return error_message('invalid request_id'), 400
 
-    sample_response = {"request_id": request_id, "url": "https://example.com/", "timeout": "2022-04-14T19:58:51.598Z"}
+    # url = aws.get_url(config.STAGE_BUCKET, request_id, config.API_URL_EXPIRY)
+    url = "example.com"
+
+    timeout = datetime.utcnow() + timedelta(seconds=config.API_URL_EXPIRY)
+    timeout_str = str(timeout.replace(microsecond=0, tzinfo=timezone.utc).isoformat())
+
+    sample_response = {"request_id": request_id, "url": url, "timeout": timeout_str}
 
     return jsonify(sample_response)
 

--- a/src/storage_broker/api/__init__.py
+++ b/src/storage_broker/api/__init__.py
@@ -23,8 +23,9 @@ def get_archive_url():
     except ValueError:
         return error_message('invalid request_id'), 400
 
-    # url = aws.get_url(config.STAGE_BUCKET, request_id, config.API_URL_EXPIRY)
-    url = "example.com"
+    url = aws.get_url(config.STAGE_BUCKET, request_id, config.API_URL_EXPIRY)
+    if not url:
+        return error_message('payload for the request_id may not be available'), 400
 
     timeout = datetime.utcnow() + timedelta(seconds=config.API_URL_EXPIRY)
     timeout_str = str(timeout.replace(microsecond=0, tzinfo=timezone.utc).isoformat())

--- a/src/storage_broker/api/__init__.py
+++ b/src/storage_broker/api/__init__.py
@@ -30,9 +30,9 @@ def get_archive_url():
     timeout = datetime.utcnow() + timedelta(seconds=config.API_URL_EXPIRY)
     timeout_str = str(timeout.replace(microsecond=0, tzinfo=timezone.utc).isoformat())
 
-    sample_response = {"request_id": request_id, "url": url, "timeout": timeout_str}
+    response = {"request_id": request_id, "url": url, "timeout": timeout_str}
 
-    return jsonify(sample_response)
+    return jsonify(response)
 
 
 def main():

--- a/src/storage_broker/api/__init__.py
+++ b/src/storage_broker/api/__init__.py
@@ -23,9 +23,12 @@ def get_archive_url():
     except ValueError:
         return error_message('invalid request_id'), 400
 
+    key_check_exception = aws.check_key(config.STAGE_BUCKET, request_id)
+    if key_check_exception:
+        client_error_msg, error_code = key_check_exception.response["Error"]["Message"], key_check_exception.response["Error"]["Code"]
+        return error_message(f"{client_error_msg} - {error_code}"), 400
+
     url = aws.get_url(config.STAGE_BUCKET, request_id, config.API_URL_EXPIRY)
-    if not url:
-        return error_message('aws client error'), 500
 
     timeout = datetime.utcnow() + timedelta(seconds=config.API_URL_EXPIRY)
     timeout_str = str(timeout.replace(microsecond=0, tzinfo=timezone.utc).isoformat())

--- a/src/storage_broker/storage/aws.py
+++ b/src/storage_broker/storage/aws.py
@@ -25,3 +25,8 @@ def copy(key, src, dest, new_key, size, service):
     except Exception:
         logger.exception("Unable to move %s to %s bucket", key, dest)
         metrics.storage_copy_error.labels(bucket=dest).inc()
+
+@metrics.presigned_url_gen_time.time()
+def get_url(bucket, request_id, expiry):
+    url = s3.generate_presigned_url("get_object", Params={"Bucket": bucket, "Key": request_id}, ExpiresIn=expiry)
+    return url

--- a/src/storage_broker/storage/aws.py
+++ b/src/storage_broker/storage/aws.py
@@ -27,11 +27,17 @@ def copy(key, src, dest, new_key, size, service):
         logger.exception("Unable to move %s to %s bucket", key, dest)
         metrics.storage_copy_error.labels(bucket=dest).inc()
 
+@metrics.storage_key_check_time.time()
+def check_key(bucket, request_id):
+    try:
+        s3.head_object(Bucket=bucket, Key=request_id)
+        return None
+    except ClientError as e:
+        return e
+
 @metrics.presigned_url_gen_time.time()
 def get_url(bucket, request_id, expiry):
     try:
-        url = s3.generate_presigned_url("get_object", Params={"Bucket": bucket, "Key": request_id}, ExpiresIn=expiry)
+        return s3.generate_presigned_url("get_object", Params={"Bucket": bucket, "Key": request_id}, ExpiresIn=expiry)
     except ClientError:
-        return None
-
-    return url
+        raise

--- a/src/storage_broker/storage/aws.py
+++ b/src/storage_broker/storage/aws.py
@@ -1,5 +1,6 @@
 import logging
 import boto3
+from botocore.exceptions import ClientError
 
 from src.storage_broker.utils import config
 from src.storage_broker.utils import metrics
@@ -28,5 +29,9 @@ def copy(key, src, dest, new_key, size, service):
 
 @metrics.presigned_url_gen_time.time()
 def get_url(bucket, request_id, expiry):
-    url = s3.generate_presigned_url("get_object", Params={"Bucket": bucket, "Key": request_id}, ExpiresIn=expiry)
+    try:
+        url = s3.generate_presigned_url("get_object", Params={"Bucket": bucket, "Key": request_id}, ExpiresIn=expiry)
+    except ClientError:
+        return None
+
     return url

--- a/src/storage_broker/utils/config.py
+++ b/src/storage_broker/utils/config.py
@@ -82,6 +82,7 @@ KAFKA_QUEUE_MAX_KBYTES = os.getenv("KAFKA_QUEUE_MAX_KBYTES", 1024)
 KAFKA_ALLOW_CREATE_TOPICS = os.getenv("KAFKA_ALLOW_CREATE_TOPICS", False)
 
 API_PORT = os.getenv("API_PORT", 5000)
+API_URL_EXPIRY = int(os.getenv("API_URL_EXPIRY", 3600))
 
 # We need to support local or policy based keys that don't work with clowder
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", AWS_ACCESS_KEY_ID)

--- a/src/storage_broker/utils/metrics.py
+++ b/src/storage_broker/utils/metrics.py
@@ -51,3 +51,7 @@ storage_copy_time = Histogram(
     "storage_broker_object_copy_time_seconds",
     "Total time it takes to copy an object from one bucket to another",
 )
+presigned_url_gen_time = Histogram(
+    "storage_broker_presigned_url_gen_time_seconds",
+    "Total time it takes to generate a presigned url for a payload",
+)

--- a/src/storage_broker/utils/metrics.py
+++ b/src/storage_broker/utils/metrics.py
@@ -51,6 +51,10 @@ storage_copy_time = Histogram(
     "storage_broker_object_copy_time_seconds",
     "Total time it takes to copy an object from one bucket to another",
 )
+storage_key_check_time = Histogram(
+    "storage_broker_storage_key_check_time_seconds",
+    "Total time it takes to check a key exists in a bucket",
+)
 presigned_url_gen_time = Histogram(
     "storage_broker_presigned_url_gen_time_seconds",
     "Total time it takes to generate a presigned url for a payload",


### PR DESCRIPTION
## What?
This PR adds support for the presigned url generation for the `/archive/url` endpoint. Last piece of the work for [RHCLOUD-18663](https://issues.redhat.com/browse/RHCLOUD-18663).

## Why?
:arrow_up: 

## How?
* adds `get_url` function to fetch a presigned url from aws
* plugs the `get_url` function to the `/archive/url` endpoint
* adds appropriate metrics and environment variable

## Testing
Tested locally with Minio.

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
