### PR TITLE
[api] Add root url and proper listen address

### DIFF
--- a/src/storage_broker/api/__init__.py
+++ b/src/storage_broker/api/__init__.py
@@ -37,10 +37,14 @@ def get_archive_url():
 
     return jsonify(response)
 
+@app.route("/", methods=['GET'])
+def health_check():
+    return jsonify({"status": "ok"})
+
 
 def main():
     logger.info("Starting storage broker api...")
-    app.run(port=config.API_PORT)
+    app.run(host=config.API_LISTEN_ADDRESS, port=config.API_PORT)
 
 
 def error_message(message):

--- a/src/storage_broker/utils/config.py
+++ b/src/storage_broker/utils/config.py
@@ -83,6 +83,7 @@ GROUP_ID = os.getenv("GROUP_ID", APP_NAME)
 KAFKA_QUEUE_MAX_KBYTES = os.getenv("KAFKA_QUEUE_MAX_KBYTES", 1024)
 KAFKA_ALLOW_CREATE_TOPICS = os.getenv("KAFKA_ALLOW_CREATE_TOPICS", False)
 
+API_LISTEN_ADDRESS = os.getenv("API_LISTEN_ADDRESS", "0.0.0.0")
 API_URL_EXPIRY = int(os.getenv("API_URL_EXPIRY", 3600))
 
 # We need to support local or policy based keys that don't work with clowder


### PR DESCRIPTION
We need a decent root address in the API for quick tests. Also added a
listen address config option so we could set it to 0.0.0.0 for outside
apps to reach it

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Add a listen address and / endpoint

## Why?
Outside pods can't reach the API when it uses 127.0.0.1, so we had to update that so pods can query it. The '/' endpoint is just to simplify API listening checks

## How?
Added to api/__init__.py and config options

## Testing
None

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
