### PR TITLE
[fix] Allow s3_endpoint to be set by env var

### DIFF
--- a/src/storage_broker/utils/config.py
+++ b/src/storage_broker/utils/config.py
@@ -47,6 +47,7 @@ if os.getenv("ACG_CONFIG"):
     AWS_SECRET_ACCESS_KEY = cfg.objectStore.secretKey
     STAGE_BUCKET = ObjectBuckets[os.environ.get("PERM_BUCKET")].name
     REJECT_BUCKET = ObjectBuckets[os.environ.get("REJECT_BUCKET")].name
+    S3_ENDPOINT_URL = f"{cfg.objectStore.hostname}:{cfg.objectStore.port}"
     # Logging
     CW_AWS_ACCESS_KEY_ID = os.getenv(
         "CW_AWS_ACCESS_KEY_ID", cfg.logging.cloudwatch.accessKeyId
@@ -71,6 +72,7 @@ else:
     AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", None)
     STAGE_BUCKET = os.getenv("STAGE_BUCKET", "insights-dev-upload-perm")
     REJECT_BUCKET = os.getenv("REJECT_BUCKET", "insights-dev-upload-rejected")
+    S3_ENDPOINT_URL = os.getenv("S3_ENDPOINT_URL", None)
     # Logging
     CW_AWS_ACCESS_KEY_ID = os.getenv("CW_AWS_ACCESS_KEY_ID", None)
     CW_AWS_SECRET_ACCESS_KEY = os.getenv("CW_AWS_SECRET_ACCESS_KEY", None)
@@ -91,7 +93,6 @@ AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", AWS_ACCESS_KEY_ID)
 AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", AWS_SECRET_ACCESS_KEY)
 
 AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
-S3_ENDPOINT_URL = os.getenv("S3_ENDPOINT_URL", None)
 BUCKET_MAP_FILE = os.getenv("BUCKET_MAP_FILE", "/opt/app-root/src/default_map.yaml")
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")

--- a/src/storage_broker/utils/config.py
+++ b/src/storage_broker/utils/config.py
@@ -47,7 +47,7 @@ if os.getenv("ACG_CONFIG"):
     AWS_SECRET_ACCESS_KEY = cfg.objectStore.secretKey
     STAGE_BUCKET = ObjectBuckets[os.environ.get("PERM_BUCKET")].name
     REJECT_BUCKET = ObjectBuckets[os.environ.get("REJECT_BUCKET")].name
-    S3_ENDPOINT_URL = f"{cfg.objectStore.hostname}:{cfg.objectStore.port}"
+    S3_ENDPOINT_URL = cfg.objectStore.hostname
     # Logging
     CW_AWS_ACCESS_KEY_ID = os.getenv(
         "CW_AWS_ACCESS_KEY_ID", cfg.logging.cloudwatch.accessKeyId

--- a/src/storage_broker/utils/config.py
+++ b/src/storage_broker/utils/config.py
@@ -47,7 +47,7 @@ if os.getenv("ACG_CONFIG"):
     AWS_SECRET_ACCESS_KEY = cfg.objectStore.secretKey
     STAGE_BUCKET = ObjectBuckets[os.environ.get("PERM_BUCKET")].name
     REJECT_BUCKET = ObjectBuckets[os.environ.get("REJECT_BUCKET")].name
-    S3_ENDPOINT_URL = cfg.objectStore.hostname
+    S3_ENDPOINT_URL = f"http://{cfg.objectStore.hostname}:{cfg.objectStore.port}"
     # Logging
     CW_AWS_ACCESS_KEY_ID = os.getenv(
         "CW_AWS_ACCESS_KEY_ID", cfg.logging.cloudwatch.accessKeyId


### PR DESCRIPTION
This will fix an issue when amazon s3 is not the storage endpoint. We
can pull it from clowdapp instead

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
The S3 Endpoint can be set by clowdapp

## Why?
WE need this particularly for ephemeral environments

## How?
Tell storage-broker to pull the hostname of the cloud storage from clowdapp

## Testing
N/A

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
