### PR TITLE
Decrease API_URL_EXPIRY to 30 seconds

### DIFF
--- a/src/storage_broker/utils/config.py
+++ b/src/storage_broker/utils/config.py
@@ -86,7 +86,7 @@ KAFKA_QUEUE_MAX_KBYTES = os.getenv("KAFKA_QUEUE_MAX_KBYTES", 1024)
 KAFKA_ALLOW_CREATE_TOPICS = os.getenv("KAFKA_ALLOW_CREATE_TOPICS", False)
 
 API_LISTEN_ADDRESS = os.getenv("API_LISTEN_ADDRESS", "0.0.0.0")
-API_URL_EXPIRY = int(os.getenv("API_URL_EXPIRY", 3600))
+API_URL_EXPIRY = int(os.getenv("API_URL_EXPIRY", 30))
 
 # We need to support local or policy based keys that don't work with clowder
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", AWS_ACCESS_KEY_ID)


### PR DESCRIPTION
## What?
Decrease the timeout for archive links from 1 hour to 30 seconds

## Why?
These generated URLs are only meant to be clicked once, so they do not need a long timeout duration. Additionally, this could be seen as added security for these links.
