### PR TITLE
Fix S3 Copy Errors metric [RHCLOUD-19095]

### DIFF
--- a/dashboards/grafana-dashboard-insights-storage-broker-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-storage-broker-general.configmap.yaml
@@ -121,7 +121,7 @@ data:
           "pluginVersion": "7.2.1",
           "targets": [
             {
-              "expr": "sum(increase(storage_broker_object_copy_error_count_total[24h]) or (up * 0)) / sum(increase(storage_broker_object_copy_success_count_total[24h])) + sum(increase(storage_broker_object_copy_error_count_total[24h]) or (up * 0))",
+              "expr": "sum(increase(storage_broker_object_copy_error_count_total[24h]) or (up * 0)) / (sum(increase(storage_broker_object_copy_error_count_total[24h]) or (up * 0)) + sum(increase(storage_broker_object_copy_success_count_total[24h])))",
               "interval": "",
               "legendFormat": "",
               "refId": "A"

--- a/dashboards/grafana-dashboard-insights-storage-broker-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-storage-broker-general.configmap.yaml
@@ -121,7 +121,7 @@ data:
           "pluginVersion": "7.2.1",
           "targets": [
             {
-              "expr": "sum(increase(storage_broker_object_copy_error_count_total[24h])) / sum(increase(storage_broker_object_copy_success_count_total[24h])) + sum(increase(storage_broker_object_copy_error_count_total[24h]))",
+              "expr": "sum(increase(storage_broker_object_copy_error_count_total[24h]) or (up * 0)) / sum(increase(storage_broker_object_copy_success_count_total[24h])) + sum(increase(storage_broker_object_copy_error_count_total[24h]) or (up * 0))",
               "interval": "",
               "legendFormat": "",
               "refId": "A"


### PR DESCRIPTION
## What?
Fix  `S3 Copy Errors` metric in Grafana
Part of [RHCLOUD-19095](https://issues.redhat.com/browse/RHCLOUD-19095)

## Why?
Allows for visibility of an increase in % of copy errors.

## How?

- Fixed expression calculation
- handled empty copy errors in `storage_broker_object_copy_error_count_total` metric by defaulting `(up * 0)` 
(see [here](https://www.robustperception.io/existential-issues-with-metrics/#:~:text=For%20the%20case%20where%20you%27re%20working%20with%20a%20metric%20that%20may%20not%20exist%2C%20such%20as%20the%20success/failure%20example%2C%20the%20approach%20is%20to%20or%20in%20the%20missing%20labelsets%20based%20on%20some%20metric%20we%20know%20exists%20%2D%20commonly%20up.%20So%20for%20example%20the%20failure%20ratio%20from%20above%C2%A0would%20become%3A))

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
