### PR TITLE
fix protocol mismatch in S3_ENDPOINT_URL

### DIFF
--- a/src/storage_broker/utils/config.py
+++ b/src/storage_broker/utils/config.py
@@ -47,7 +47,10 @@ if os.getenv("ACG_CONFIG"):
     AWS_SECRET_ACCESS_KEY = cfg.objectStore.secretKey
     STAGE_BUCKET = ObjectBuckets[os.environ.get("PERM_BUCKET")].name
     REJECT_BUCKET = ObjectBuckets[os.environ.get("REJECT_BUCKET")].name
-    S3_ENDPOINT_URL = f"http://{cfg.objectStore.hostname}:{cfg.objectStore.port}"
+    if cfg.objectStore.port != 443:
+        S3_ENDPOINT_URL = f"http://{cfg.objectStore.hostname}:{cfg.objectStore.port}"
+    else:
+        S3_ENDPOINT_URL = f"https://{cfg.objectStore.hostname}:{cfg.objectStore.port}"
     # Logging
     CW_AWS_ACCESS_KEY_ID = os.getenv(
         "CW_AWS_ACCESS_KEY_ID", cfg.logging.cloudwatch.accessKeyId


### PR DESCRIPTION
Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
S3 Endpoint URL should use https when hitting port 443 at S3. Right now it's mismatching the port and protocol.

## Why?
Calls to the S3 service are failing

## How?
Make it conditional depending on if we're using a secure port or not

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
