### PR TITLE
Switch to single-topic message consumption

### DIFF
--- a/default_map.yaml
+++ b/default_map.yaml
@@ -1,6 +1,6 @@
 platform.upload.validation:
   normalizer: Validation
-platform.upload.buckit:
+platform.upload.announce:
   normalizer: Openshift
   services:
     openshift:

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -117,6 +117,9 @@ objects:
       - replicas: 3
         partitions: 3
         topicName: platform.notifications.ingress
+      - replicas: 3
+        partitions: 64
+        topicName: platform.upload.announce
 - apiVersion: v1
   kind: ConfigMap
   metadata:
@@ -125,7 +128,7 @@ objects:
     config.yaml: |-
       platform.upload.validation:
         normalizer: Validation
-      platform.upload.buckit:
+      platform.upload.announce:
         normalizer: Openshift
         services:
           openshift:

--- a/src/storage_broker/app.py
+++ b/src/storage_broker/app.py
@@ -113,6 +113,9 @@ def main(exit_event=event):
             logger.error("Consumer error: %s", msg.error())
             continue
 
+        if msg.topic() != config.EGRESS_TOPIC and not service_check(msg):
+            continue
+
         try:
             decoded_msg = json.loads(msg.value().decode("utf-8"))
             logger.debug("Incoming Message Content: %s", decoded_msg)
@@ -128,9 +131,6 @@ def main(exit_event=event):
                 track_inventory_payload(decoded_msg)
             continue
 
-        if not service_check(msg):
-            logger.debug("Message not for monitored service")
-            continue
         try:
             _map = bucket_map[msg.topic()]
             data = normalize(_map, decoded_msg)

--- a/src/storage_broker/mq/consume.py
+++ b/src/storage_broker/mq/consume.py
@@ -30,11 +30,11 @@ def init_consumer(logger):
        logger.debug("Connected to consumer")
 
        consumer.subscribe(
-           [config.VALIDATION_TOPIC, config.EGRESS_TOPIC, config.STORAGE_TOPIC]
+           [config.VALIDATION_TOPIC, config.EGRESS_TOPIC, config.INGRESS_TOPIC]
        )
        logger.debug("Subscribed to topics [%s, %s, %s]", config.VALIDATION_TOPIC,
                                                          config.EGRESS_TOPIC, 
-                                                         config.STORAGE_TOPIC)
+                                                         config.INGRESS_TOPIC)
        return consumer
     except Exception as e:
         logger.error("Failed to initialize consumer: %s", e)

--- a/src/storage_broker/utils/config.py
+++ b/src/storage_broker/utils/config.py
@@ -60,7 +60,7 @@ if os.getenv("ACG_CONFIG"):
     KAFKA_BROKER = cfg.kafka.brokers[0]
     BUCKET_MAP = clowderize_bucket_map(load_bucket_map(BUCKET_MAP_FILE), KafkaTopics)
     VALIDATION_TOPIC = KafkaTopics["platform.upload.validation"].name
-    STORAGE_TOPIC = KafkaTopics["platform.upload.buckit"].name
+    INGRESS_TOPIC = KafkaTopics["platform.upload.announce"].name
     EGRESS_TOPIC = KafkaTopics["platform.inventory.events"].name
     NOTIFICATIONS_TOPIC = KafkaTopics["platform.notifications.ingress"].name
     TRACKER_TOPIC = KafkaTopics["platform.payload-status"].name
@@ -89,7 +89,7 @@ else:
     KAFKA_BROKER = None
     BUCKET_MAP = load_bucket_map(BUCKET_MAP_FILE)
     VALIDATION_TOPIC = os.getenv("CONSUME_TOPIC", "platform.upload.validation")
-    STORAGE_TOPIC = os.getenv("STORAGE_TOPIC", "platform.upload.buckit")
+    INGRESS_TOPIC = os.getenv("INGRESS_TOPIC", "platform.upload.announce")
     EGRESS_TOPIC = os.getenv("EGRESS_TOPIC", "platform.inventory.events")
     NOTIFICATIONS_TOPIC = os.getenv("NOTIFICATIONS_TOPIC", "platform.notifications.ingress")
     TRACKER_TOPIC = os.getenv("TRACKER_TOPIC", "platform.payload-status")
@@ -112,6 +112,7 @@ GROUP_ID = os.getenv("GROUP_ID", APP_NAME)
 KAFKA_QUEUE_MAX_KBYTES = os.getenv("KAFKA_QUEUE_MAX_KBYTES", 1024)
 KAFKA_ALLOW_CREATE_TOPICS = os.getenv("KAFKA_ALLOW_CREATE_TOPICS", False)
 KAFKA_LOG_LEVEL = os.getenv("KAFKA_LOG_LEVEL", "ERROR")
+MONITORED_SERVICES = os.getenv("MONITORED_SERVICES", "openshift,ansible").split(",")
 
 API_LISTEN_ADDRESS = os.getenv("API_LISTEN_ADDRESS", "0.0.0.0")
 API_URL_EXPIRY = int(os.getenv("API_URL_EXPIRY", 30))


### PR DESCRIPTION
The big change here is in the topic we're consuming from and we're now
checking a header to see if we should care about it.

It's worthing noting that the validation and egress are not impacted by
this update.

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Updating the topic we consume from when consuming openshift (CCX) and ansible (Tower) content types

## Why?
We need this for handling anemic tenants

## How?
Create a function to check the service header of the kafka message to see if it is for us.

## Testing


## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
