### PR TITLE
[refactor] Remove old inventory events related code

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,30 +59,6 @@ added as attributes of your normalizer class.
 
 The only **required** keys in a normalizer at this point are `size`, `service`, and `request_id`. Any other keys you establish can be used for formatting the resulting object filename.
 
-## Available Message
-
-Available Message:
-
-      {
-          "account": <account number>,
-          "request_id": <uuid for the payload>,
-          "principal": <currently the org ID>,
-          "service": <the service that validated the payload>,
-          "category": <a category for the payload>,
-          "url": <URL to download the file>,
-          "b64_identity": <the base64 encoded identity of the sender>,
-          "id": <host based inventory id if available>, **RELOCATING TO EXTRAS**
-          "satellite_managed": <boolean if the system is managed by satellite>, **RELOCATING TO EXTRAS**
-          "timestamp": <the time the available message was put on the topic>,
-          "validation": <success|failure>,
-          "size": <size in bytes of payload>,
-          "metadata": <metadata attached to the original upload>,
-          "extras": {
-              "satellite_managed": <same as above>
-              "id": <same as above>
-              ...
-          }
-      }
 
 ## Local Development
 

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -106,9 +106,6 @@ objects:
         partitions: 16
         topicName: platform.upload.buckit
       - replicas: 3
-        partitions: 64
-        topicName: platform.inventory.events
-      - replicas: 3
         partitions: 4
         topicName: platform.payload-status
       - replicas: 3

--- a/src/storage_broker/app.py
+++ b/src/storage_broker/app.py
@@ -113,7 +113,7 @@ def main(exit_event=event):
             logger.error("Consumer error: %s", msg.error())
             continue
 
-        if msg.topic() != config.EGRESS_TOPIC and not service_check(msg):
+        if not service_check(msg):
             continue
 
         try:
@@ -130,11 +130,6 @@ def main(exit_event=event):
             if decoded_msg['type'] in ('updated', 'created'):
                 track_inventory_payload(decoded_msg)
             continue
-
-        tracker_msg = TrackerMessage(attr.asdict(decoded_msg))
-        send_message(TRACKER_TOPIC, tracker_msg.message("received",
-                                                        "received message for {}".format(tracker_msg.service)),
-                                                        request_id=tracker_msg.request_id)
 
         try:
             _map = bucket_map[msg.topic()]

--- a/src/storage_broker/mq/consume.py
+++ b/src/storage_broker/mq/consume.py
@@ -30,10 +30,9 @@ def init_consumer(logger):
        logger.debug("Connected to consumer")
 
        consumer.subscribe(
-           [config.VALIDATION_TOPIC, config.EGRESS_TOPIC, config.INGRESS_TOPIC]
+           [config.VALIDATION_TOPIC, config.INGRESS_TOPIC]
        )
        logger.debug("Subscribed to topics [%s, %s, %s]", config.VALIDATION_TOPIC,
-                                                         config.EGRESS_TOPIC, 
                                                          config.INGRESS_TOPIC)
        return consumer
     except Exception as e:

--- a/src/storage_broker/utils/config.py
+++ b/src/storage_broker/utils/config.py
@@ -61,7 +61,6 @@ if os.getenv("ACG_CONFIG"):
     BUCKET_MAP = clowderize_bucket_map(load_bucket_map(BUCKET_MAP_FILE), KafkaTopics)
     VALIDATION_TOPIC = KafkaTopics["platform.upload.validation"].name
     INGRESS_TOPIC = KafkaTopics["platform.upload.announce"].name
-    EGRESS_TOPIC = KafkaTopics["platform.inventory.events"].name
     NOTIFICATIONS_TOPIC = KafkaTopics["platform.notifications.ingress"].name
     TRACKER_TOPIC = KafkaTopics["platform.payload-status"].name
     BOOTSTRAP_SERVERS = f"{KAFKA_BROKER.hostname}:{KAFKA_BROKER.port}"
@@ -90,7 +89,6 @@ else:
     BUCKET_MAP = load_bucket_map(BUCKET_MAP_FILE)
     VALIDATION_TOPIC = os.getenv("CONSUME_TOPIC", "platform.upload.validation")
     INGRESS_TOPIC = os.getenv("INGRESS_TOPIC", "platform.upload.announce")
-    EGRESS_TOPIC = os.getenv("EGRESS_TOPIC", "platform.inventory.events")
     NOTIFICATIONS_TOPIC = os.getenv("NOTIFICATIONS_TOPIC", "platform.notifications.ingress")
     TRACKER_TOPIC = os.getenv("TRACKER_TOPIC", "platform.payload-status")
     BOOTSTRAP_SERVERS = os.getenv("BOOTSTRAP_SERVERS", "kafka:29092").split()


### PR DESCRIPTION
We don't forward inventory events anymore, so we can safely remove this.

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
We pulled out sending messages to the availble topic a while back, but we still consumed inventory events. We don't need to do that anymore. This repositions storage-broker to manage validation failures and bucket moves within AWS, which was it's original intent.

## Why?
We pulled out sending messages to the availble topic a while back, but we still consumed inventory events. We don't need to do that anymore.

## How?
Renamed a few functions and added some message sending logic for the tracker

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
