### PR TITLE
[bucket] Add a new bucket

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -98,6 +98,7 @@ objects:
       - ${REJECT_BUCKET}
       - ${OPENSHIFT_BUCKET}
       - ${ANSIBLE_BUCKET}
+      - ${TOWER_BUCKET}
     kafkaTopics:
       - replicas: 3
         partitions: 24
@@ -134,6 +135,12 @@ objects:
           ansible:
             format: "{org_id}/{cluster_id}/{timestamp}-{request_id}"
             bucket: ${ANSIBLE_BUCKET}
+          tower:
+            format: "{request_id}"
+            bucket: ${TOWER_BUCKET}
+          pinakes:
+            format: "{request_id}"
+            bucket: ${TOWER_BUCKET}
   
 parameters:
 - description: Minimum number of replicas required
@@ -180,6 +187,9 @@ parameters:
 - description: ansible tower bucket
   name: ANSIBLE_BUCKET
   value: "insights-buck-it-ansible"
+- description: tower analytics bucket
+  name: TOWER_BUCKET
+  value: "insights-upload-tower-analytics"
 - description: bucket config map location
   name: BUCKET_MAP_FILE
   value: "/var/config.yaml"


### PR DESCRIPTION
Add a bucket for tower analytics payloads

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Explain what the change is linking any relevant JIRAs or Issues.

Add a bucket to the configMap for tower analytics archives

[RHCLOUD-2129](https://issues.redhat.com/browse/RHCLOUD-21129)

## Why?
Consider what business or engineering goal does this PR achieves.

The tower analytics team requires their payloads to be around for longer
than our default bucket expirations. This bucket will expire the payloads in 90 days
rather than 24 hours.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

Storage broker has a configMap to make these tasks simple. We simply add the service,
bucket details, and format to the configMap and we're good to go. Payload will be
copied over.

## Testing
Did you add any tests for the change?

Testing it out in stage.

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
