### PR TITLE
Add requirements.txt file for RHCLOUD-21527

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+app_common_python==0.2.3
+attr==0.3.2
+attrs==21.2.0
+boto3==1.24.89
+botocore==1.27.89
+confluent_kafka==1.9.2
+Flask==2.2.2
+logstash_formatter==0.5.17
+prometheus_client==0.14.1
+PyYAML==6.0
+setuptools==65.3.0
+watchtower==3.0.0


### PR DESCRIPTION
## What?
Adding requirements.txt to repo for [RHCLOUD-21527](https://issues.redhat.com/browse/RHCLOUD-21527)

## Why?
Improve dependency tracking

## How?
File built using the pipreqs (https://github.com/bndr/pipreqs) tool