### PR TITLE
update clowdapp memory defaults

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -153,7 +153,7 @@ parameters:
   value: 250m
 - description: memory request of service
   name: MEMORY_REQUEST
-  value: 64Mi
+  value: 256Mi
 - description: Image tag
   name: IMAGE_TAG
   required: true


### PR DESCRIPTION
## What?
Update the default memory values, so that when deployed to ephemeral they align with the resource-limit LimitRange

## Why?
Recently, insights storage broker started getting automatically deployed to ephemeral environments. The default memory values in the clowdapp.yaml do not align with the ephemeral quotas causing pr_checks to fail.

https://github.com/RedHatInsights/insights-storage-broker/issues/95

## Testing
Updating the storage-broker clowdapp in an ephemeral environment before the bonfire command times out allows the deployment to succeed.
