### PR TITLE
fix: do not skip validation messages

### DIFF
--- a/src/storage_broker/app.py
+++ b/src/storage_broker/app.py
@@ -113,7 +113,7 @@ def main(exit_event=event):
             logger.error("Consumer error: %s", msg.error())
             continue
 
-        if not service_check(msg):
+        if not service_check(msg) and msg.topic() != config.VALIDATION_TOPIC:
             continue
 
         try:


### PR DESCRIPTION
Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

## What?
Set up the logic so that we don't skip validation messages when they do not contain a service header.

## Why?
We should always be checking the validation messages even if we don't have a service header to go with
it.

## How?
Add a check in the current if statement

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
