### PR TITLE
Update default bucket map for Hub-Analytics

### DIFF
--- a/default_map.yaml
+++ b/default_map.yaml
@@ -12,6 +12,9 @@ platform.upload.announce:
     tower:
       format: "{org_id}/{request_id}"
       bucket: "insights-upload-tower-analytics-stage"
+    automation-hub:
+      format: "{org_id}/{request_id}"
+      bucket: "insights-upload-tower-analytics-stage"
     pinakes:
       format: "{org_id}/{request_id}"
       bucket: "insights-upload-tower-analytics-stage"

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -128,7 +128,10 @@ objects:
           pinakes:
             format: "{org_id}/{request_id}"
             bucket: ${TOWER_BUCKET}
-  
+          automation-hub:
+            format: "{org_id}/{request_id}"
+            bucket: ${TOWER_BUCKET}
+
 parameters:
 - description: Minimum number of replicas required
   name: MIN_REPLICAS


### PR DESCRIPTION
## What?
Explain what the change is linking any relevant JIRAs or Issues.

Extends Analytics bucket for receiving Automation Hub/Galaxy tarballs

Follow up https://github.com/RedHatInsights/insights-storage-broker/pull/92

- https://issues.redhat.com/browse/AA-1758
- https://issues.redhat.com/browse/AA-1343

`automation-hub` content type registered here: https://github.com/RedHatInsights/insights-ingress-go/pull/328

## Why?
Consider what business or engineering goal does this PR achieves.

24 hours of Ingress bucket is not acceptable ( == safe) for Analytics

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
