### PR TITLE
Move security-compliance pipelines to master

### DIFF
--- a/.tekton/storage-broker-push.yaml
+++ b/.tekton/storage-broker-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: storage-broker
@@ -26,14 +27,7 @@ spec:
   - name: dockerfile
     value: Dockerfile
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build-oci-ta.yaml
-    resolver: git
+    name: docker-build-oci-ta
   taskRunTemplate:
     serviceAccountName: build-pipeline-storage-broker
   workspaces:

--- a/.tekton/storage-broker-sc-pull-request.yaml
+++ b/.tekton/storage-broker-sc-pull-request.yaml
@@ -8,14 +8,14 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "master"
+      == "security-compliance"
     pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: storage-broker
-    appstudio.openshift.io/component: storage-broker
+    appstudio.openshift.io/application: storage-broker-sc
+    appstudio.openshift.io/component: storage-broker-sc
     pipelines.appstudio.openshift.io/type: build
-  name: storage-broker-on-pull-request
+  name: storage-broker-sc-on-pull-request
   namespace: hcc-integrations-tenant
 spec:
   params:
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/storage-broker/storage-broker:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/storage-broker-sc/storage-broker-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
@@ -32,7 +32,7 @@ spec:
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:
-    serviceAccountName: build-pipeline-storage-broker
+    serviceAccountName: build-pipeline-storage-broker-sc
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/storage-broker-sc-push.yaml
+++ b/.tekton/storage-broker-sc-push.yaml
@@ -4,18 +4,17 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/RedHatInsights/insights-storage-broker?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "security-compliance"
     pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: storage-broker
-    appstudio.openshift.io/component: storage-broker
+    appstudio.openshift.io/application: storage-broker-sc
+    appstudio.openshift.io/component: storage-broker-sc
     pipelines.appstudio.openshift.io/type: build
-  name: storage-broker-on-pull-request
+  name: storage-broker-sc-on-push
   namespace: hcc-integrations-tenant
 spec:
   params:
@@ -24,15 +23,13 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/storage-broker/storage-broker:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/storage-broker-sc/storage-broker-sc:{{revision}}
   - name: dockerfile
     value: Dockerfile
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:
-    serviceAccountName: build-pipeline-storage-broker
+    serviceAccountName: build-pipeline-storage-broker-sc
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
## What?
This PR introduces in the `master` branch the Konflux pipeline definitions required to build and release the `security-compliance` branch.

## Why?
Every 30 days, the `security-compliance` branch is reset to a given Git sha from the `master` branch. Any changes made directly in the `security-compliance` branch are therefore overridden and lost. As a consequence, the maintenance of the pipelines for `security-compliance` has to be made in the `master` branch.