### PR TITLE
Add S3 bucket route for OLS

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -125,6 +125,9 @@ objects:
           automation-hub:
             format: "{org_id}/{request_id}"
             bucket: ${TOWER_BUCKET}
+          ols:
+            format: "{service}/{org_id}/{cluster_id}/{timestamp}/{request_id}.tgz"
+            bucket: ${LIGHTSPEED_ASSISTANTS_BUCKET}
 
 parameters:
 - description: Minimum number of replicas required
@@ -183,4 +186,6 @@ parameters:
 - description: policy based key
   name: POLICY_BASED_KEY
   value: "ingress-buckets-read-write"
-
+- description: bucket for data from lightspeed assistants
+  name: LIGHTSPEED_ASSISTANTS_BUCKET
+  value: "rh-lightspeed-assistant-archives"


### PR DESCRIPTION
## What?
We want to leverage this storage broker to store the data we send to ingress directly in the bucket.

JIRA issue: https://issues.redhat.com/browse/CCXDEV-15263
Related PR in insights-ingress-go repo: https://github.com/RedHatInsights/insights-ingress-go/pull/536

## Why?
To store the data from openshift-lightspeed (ols) assistant.

## How?
Adding `ols` service and relevant S3 bucket.

## Testing
Did you add any tests for the change?
No

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 
No

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
