### PR TITLE
[RHCLOUD-41237] Add timestamp attribute into the Validation normalizer

### DIFF
--- a/src/storage_broker/normalizers.py
+++ b/src/storage_broker/normalizers.py
@@ -30,6 +30,7 @@ class Validation(object):
     system_id = attr.ib(default=None)
     hostname = attr.ib(default=None)
     size = attr.ib(default=None)
+    timestamp = attr.ib(default=datetime.utcnow().strftime("%Y%m%d%H%M%S"))
 
 
     @classmethod
@@ -60,7 +61,8 @@ class Validation(object):
             return cls(
                 validation=validation, service=service, request_id=request_id,
                 reason=reason, reporter=reporter, system_id=system_id,
-                hostname=hostname, account=account, org_id=org_id, size=size
+                hostname=hostname, account=account, org_id=org_id, size=size,
+                timestamp=datetime.utcnow().strftime("%Y%m%d%H%M%S"),
             )
         except Exception:
             logger.exception("Unable to deserialize JSON: %s", doc)


### PR DESCRIPTION
## What?
Adding a "timestamp" attribute into Validation normalizer.

## Why?
We need this attribute to help onboard more lightspeed teams into insights-storage-broker.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
