### PR TITLE
Add bucket configuration for assisted-chat

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -128,6 +128,9 @@ objects:
           ols:
             format: "{service}/{org_id}/{cluster_id}/{timestamp}/{request_id}.tgz"
             bucket: ${LIGHTSPEED_ASSISTANTS_BUCKET}
+          ocm-assisted-chat:
+            format: "{service}/{org_id}/{cluster_id}/{timestamp}/{request_id}.tgz"
+            bucket: ${LIGHTSPEED_ASSISTANTS_BUCKET}
 
 parameters:
 - description: Minimum number of replicas required


### PR DESCRIPTION
This is reusing the same bucket as the lightspeed assistants for now until DataVerse is available.

Related: 

 - https://github.com/RedHatInsights/insights-ingress-go/pull/557/files
