### PR TITLE
Add S3 bucket route for openstack-lightspeed (rhos-lightspeed)

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -131,6 +131,9 @@ objects:
           ocm-assisted-chat:
             format: "{service}/{org_id}/{cluster_id}/{timestamp}/{request_id}.tgz"
             bucket: ${LIGHTSPEED_ASSISTANTS_BUCKET}
+          rhos-lightspeed:
+            format: "{service}/{org_id}/{cluster_id}/{timestamp}/{request_id}.tgz"
+            bucket: ${LIGHTSPEED_ASSISTANTS_BUCKET}
 
 parameters:
 - description: Minimum number of replicas required


### PR DESCRIPTION
Add the S3 bucket route for the openstack-lightspeed (rhos-lightspeed) service.
This uses the same bucket as the other lightspeed projects.

Related PR: https://github.com/RedHatInsights/insights-ingress-go/pull/575