### PR TITLE
feat(config): allow per-service normalizer

### DIFF
--- a/default_map.yaml
+++ b/default_map.yaml
@@ -4,17 +4,22 @@ platform.upload.announce:
   normalizer: Openshift
   services:
     openshift:
+      normalizer: Openshift
       format: "{org_id}/{cluster_id}/{timestamp}-{request_id}"
       bucket: "insights-buck-it-openshift"
     ansible:
+      normalizer: Openshift
       format: "{org_id}/{cluster_id}/{timestamp}-{request_id}"
       bucket: "insights-buck-it-ansible"
     tower:
+      normalizer: Openshift
       format: "{org_id}/{request_id}"
       bucket: "insights-upload-tower-analytics-stage"
     automation-hub:
+      normalizer: Openshift
       format: "{org_id}/{request_id}"
       bucket: "insights-upload-tower-analytics-stage"
     pinakes:
+      normalizer: Openshift
       format: "{org_id}/{request_id}"
       bucket: "insights-upload-tower-analytics-stage"

--- a/rhosak_map.yaml
+++ b/rhosak_map.yaml
@@ -4,8 +4,10 @@ platform-mq-stage.platform.upload.buckit:
   normalizer: Openshift
   services:
     openshift:
+      normalizer: Openshift
       format: "{org_id}/{cluster_id}/{timestamp}-{request_id}"
       bucket: "insights-buck-it-openshift"
     ansible:
+      normalizer: Openshift
       format: "{org_id}/{cluster_id}/{timestamp}-{request_id}"
       bucket: "insights-buck-it-ansible"

--- a/src/storage_broker/app.py
+++ b/src/storage_broker/app.py
@@ -158,10 +158,7 @@ def main(exit_event=event):
 
 
 def normalize(_map, decoded_msg, service=None):
-    normalizer_name = _map.get("normalizer")
-    if service and "services" in _map and service in _map["services"]:
-        normalizer_name = _map["services"][service].get("normalizer", normalizer_name)
-    normalizer = getattr(normalizers, normalizer_name)
+    normalizer = normalizers.resolve_normalizer(_map, service=service)
     data = normalizer.from_json(decoded_msg)
     logger.debug("Normalized Data structure: %s", data)
     return data

--- a/src/storage_broker/app.py
+++ b/src/storage_broker/app.py
@@ -128,7 +128,8 @@ def main(exit_event=event):
 
         try:
             _map = bucket_map[msg.topic()]
-            data = normalize(_map, decoded_msg)
+            service = decoded_msg.get("service")
+            data = normalize(_map, decoded_msg, service=service)
             tracker_msg = TrackerMessage(attr.asdict(data))
             if msg.topic() == config.VALIDATION_TOPIC:
                 handle_validation(data, tracker_msg)
@@ -156,8 +157,11 @@ def main(exit_event=event):
     producer.flush()
 
 
-def normalize(_map, decoded_msg):
-    normalizer = getattr(normalizers, _map["normalizer"])
+def normalize(_map, decoded_msg, service=None):
+    normalizer_name = _map.get("normalizer")
+    if service and "services" in _map and service in _map["services"]:
+        normalizer_name = _map["services"][service].get("normalizer", normalizer_name)
+    normalizer = getattr(normalizers, normalizer_name)
     data = normalizer.from_json(decoded_msg)
     logger.debug("Normalized Data structure: %s", data)
     return data

--- a/src/storage_broker/normalizers.py
+++ b/src/storage_broker/normalizers.py
@@ -1,12 +1,27 @@
 import attr
 import logging
 import json
+import sys
 import uuid
 
 from datetime import datetime, UTC
 from base64 import b64decode
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_normalizer(_map, service=None):
+    """Resolve the normalizer class for a given topic config and service.
+
+    Uses bracket access for the required topic-level ``normalizer`` key so
+    a missing key raises ``KeyError`` immediately.  When a *service* is
+    provided and the service config contains its own ``normalizer`` key,
+    that value takes precedence.
+    """
+    normalizer_name = _map["normalizer"]
+    if service and "services" in _map and service in _map["services"]:
+        normalizer_name = _map["services"][service].get("normalizer", normalizer_name)
+    return getattr(sys.modules[__name__], normalizer_name)
 
 
 def parse_identity(b64_identity):

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,119 @@
+from storage_broker import normalizers
+
+
+VALIDATION_MSG = {
+    "account": "000001",
+    "org_id": "123456",
+    "reporter": "puptoo",
+    "request_id": "12345",
+    "system_id": "abdc-1234",
+    "hostname": "hostname",
+    "validation": "failure",
+    "service": "advisor",
+    "reason": "error unpacking archive",
+    "size": "12345",
+}
+
+
+def resolve_normalizer(_map, service=None):
+    """Mirror the normalizer resolution logic from app.normalize()."""
+    normalizer_name = _map.get("normalizer")
+    if service and "services" in _map and service in _map["services"]:
+        normalizer_name = _map["services"][service].get(
+            "normalizer", normalizer_name
+        )
+    return getattr(normalizers, normalizer_name)
+
+
+def test_topic_level_normalizer():
+    """When no service is specified, use topic-level normalizer."""
+    _map = {"normalizer": "Validation"}
+    cls = resolve_normalizer(_map)
+    assert cls is normalizers.Validation
+    data = cls.from_json(VALIDATION_MSG)
+    assert data.account == "000001"
+
+
+def test_topic_level_fallback_when_service_has_no_normalizer():
+    """When service config has no normalizer key, fall back to
+    topic-level normalizer."""
+    _map = {
+        "normalizer": "Validation",
+        "services": {
+            "advisor": {
+                "format": "{org_id}/{request_id}",
+                "bucket": "test-bucket",
+            }
+        },
+    }
+    cls = resolve_normalizer(_map, service="advisor")
+    assert cls is normalizers.Validation
+    data = cls.from_json(VALIDATION_MSG)
+    assert data.service == "advisor"
+
+
+def test_service_level_normalizer_overrides_topic():
+    """When service config has a normalizer key, use it instead
+    of the topic-level normalizer."""
+    _map = {
+        "normalizer": "Openshift",
+        "services": {
+            "advisor": {
+                "normalizer": "Validation",
+                "format": "{org_id}/{request_id}",
+                "bucket": "test-bucket",
+            }
+        },
+    }
+    cls = resolve_normalizer(_map, service="advisor")
+    assert cls is normalizers.Validation
+    data = cls.from_json(VALIDATION_MSG)
+    assert data.service == "advisor"
+
+
+def test_unknown_service_uses_topic_level():
+    """When service is not in services config, use topic-level normalizer."""
+    _map = {
+        "normalizer": "Validation",
+        "services": {
+            "openshift": {
+                "normalizer": "Openshift",
+                "format": "{org_id}/{request_id}",
+                "bucket": "test-bucket",
+            }
+        },
+    }
+    cls = resolve_normalizer(_map, service="advisor")
+    assert cls is normalizers.Validation
+    data = cls.from_json(VALIDATION_MSG)
+    assert data.account == "000001"
+
+
+def test_no_services_section_uses_topic_level():
+    """When config has no services section, use topic-level normalizer."""
+    _map = {"normalizer": "Validation"}
+    cls = resolve_normalizer(_map, service="advisor")
+    assert cls is normalizers.Validation
+    data = cls.from_json(VALIDATION_MSG)
+    assert data.org_id == "123456"
+
+
+def test_different_services_different_normalizers():
+    """Different services on the same topic can use different normalizers."""
+    _map = {
+        "normalizer": "Openshift",
+        "services": {
+            "openshift": {
+                "normalizer": "Openshift",
+                "format": "{org_id}/{cluster_id}/{timestamp}-{request_id}",
+                "bucket": "insights-buck-it-openshift",
+            },
+            "advisor": {
+                "normalizer": "Validation",
+                "format": "{org_id}/{request_id}",
+                "bucket": "test-bucket",
+            },
+        },
+    }
+    assert resolve_normalizer(_map, service="openshift") is normalizers.Openshift
+    assert resolve_normalizer(_map, service="advisor") is normalizers.Validation

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,4 +1,5 @@
 from storage_broker import normalizers
+from storage_broker.normalizers import resolve_normalizer
 
 
 VALIDATION_MSG = {
@@ -13,16 +14,6 @@ VALIDATION_MSG = {
     "reason": "error unpacking archive",
     "size": "12345",
 }
-
-
-def resolve_normalizer(_map, service=None):
-    """Mirror the normalizer resolution logic from app.normalize()."""
-    normalizer_name = _map.get("normalizer")
-    if service and "services" in _map and service in _map["services"]:
-        normalizer_name = _map["services"][service].get(
-            "normalizer", normalizer_name
-        )
-    return getattr(normalizers, normalizer_name)
 
 
 def test_topic_level_normalizer():


### PR DESCRIPTION
## Summary

- Adds support for per-service normalizer configuration in the bucket map YAML, allowing different services on the same Kafka topic to use different normalizer classes (e.g., one service can use `Validation` while another uses `Openshift` on the same `platform.upload.announce` topic)
- The topic-level `normalizer` key is preserved as a backward-compatible fallback when a service does not specify its own
- Adds 6 unit tests covering all normalizer resolution scenarios (topic-level, service-level override, fallback, unknown service)

**RHCLOUD-41768**

### Changes

- `src/storage_broker/app.py` — Updated `normalize()` to check for a service-level normalizer in the config map before falling back to the topic-level normalizer. Updated `main()` to pass the service name from the decoded message.
- `default_map.yaml` / `rhosak_map.yaml` — Added explicit `normalizer` key to each service entry.
- `tests/test_normalize.py` — New test file with 6 tests for normalizer resolution logic.

### Config format

Services can now specify their own normalizer:

```yaml
platform.upload.announce:
  normalizer: Openshift           # default fallback
  services:
    openshift:
      normalizer: Openshift
      format: "{org_id}/{cluster_id}/{timestamp}-{request_id}"
      bucket: "insights-buck-it-openshift"
    ols:
      normalizer: Validation      # different normalizer for this service
      format: "{org_id}/{request_id}"
      bucket: "ols-bucket"
```

## Test plan

- [x] All 7 existing + new unit tests pass
- [ ] Verify existing services continue to work with no behavior change (backward compatible)
- [ ] Test adding a new service with a different normalizer class