### PR TITLE
fix: copy libcrypt.so to runtime for SASL dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ FROM registry.access.redhat.com/hi/python:latest-fips
 
 COPY --from=builder /usr/lib64/librdkafka* /usr/lib64/
 COPY --from=builder /usr/lib64/libsasl2* /usr/lib64/
+COPY --from=builder /usr/lib64/libcrypt.so* /usr/lib64/
 COPY --from=builder /etc/ld.so.cache /etc/ld.so.cache
 COPY --from=builder /usr/local/lib/ /usr/local/lib/
 COPY --from=builder /usr/local/lib64/ /usr/local/lib64/


### PR DESCRIPTION
libsasl2 depends on libcrypt.so.2 (from libxcrypt), which is not present in the distroless runtime image.
