### PR TITLE
fix: regenerate RPM lockfile for updated Hummingbird repo

### DIFF
--- a/.tekton/storage-broker-pull-request.yaml
+++ b/.tekton/storage-broker-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.66.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.68.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: storage-broker

--- a/.tekton/storage-broker-pull-request.yaml
+++ b/.tekton/storage-broker-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '[{"type": "pip", "path": "."}, {"type": "rpm", "path": "hermetic"}]'
+  - name: enable-package-registry-proxy
+    value: "true"
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:

--- a/.tekton/storage-broker-push.yaml
+++ b/.tekton/storage-broker-push.yaml
@@ -30,6 +30,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '[{"type": "pip", "path": "."}, {"type": "rpm", "path": "hermetic"}]'
+  - name: enable-package-registry-proxy
+    value: "true"
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:

--- a/.tekton/storage-broker-push.yaml
+++ b/.tekton/storage-broker-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.66.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.68.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: storage-broker

--- a/.tekton/storage-broker-sc-pull-request.yaml
+++ b/.tekton/storage-broker-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.66.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.68.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: storage-broker-sc

--- a/.tekton/storage-broker-sc-pull-request.yaml
+++ b/.tekton/storage-broker-sc-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '[{"type": "pip", "path": "."}, {"type": "rpm", "path": "hermetic"}]'
+  - name: enable-package-registry-proxy
+    value: "true"
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:

--- a/.tekton/storage-broker-sc-push.yaml
+++ b/.tekton/storage-broker-sc-push.yaml
@@ -30,6 +30,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '[{"type": "pip", "path": "."}, {"type": "rpm", "path": "hermetic"}]'
+  - name: enable-package-registry-proxy
+    value: "true"
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:

--- a/.tekton/storage-broker-sc-push.yaml
+++ b/.tekton/storage-broker-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.66.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.68.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: storage-broker-sc

--- a/hermetic/rpms.lock.yaml
+++ b/hermetic/rpms.lock.yaml
@@ -18,20 +18,20 @@ arches:
     name: binutils
     evr: 2.45.1-5.hum1
     sourcerpm: binutils-2.45.1-5.hum1.src.rpm
-  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/c/coreutils-9.11-1.hum1.x86_64.rpm
+  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/c/coreutils-9.11-2.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
-    size: 1400031
-    checksum: sha256:aa64c63ae16f4cf4b3acf913d0677fdebd9fc2aa9333c476a0a307b754c78c73
+    size: 1400800
+    checksum: sha256:861eefe217858c38fe4bb3eb61aa091ecaa3b3b24f06d42b833e61019f5e668d
     name: coreutils
-    evr: 9.11-1.hum1
-    sourcerpm: coreutils-9.11-1.hum1.src.rpm
-  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/c/coreutils-common-9.11-1.hum1.x86_64.rpm
+    evr: 9.11-2.hum1
+    sourcerpm: coreutils-9.11-2.hum1.src.rpm
+  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/c/coreutils-common-9.11-2.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
-    size: 2307012
-    checksum: sha256:b5d9d4803751cffa96687ef84b672b1b29ee7d711d891279e1c45d68d31de142
+    size: 2306438
+    checksum: sha256:08ad2b3e6fcd2af3e3fce0de75b48df9ae709464ba1fc931bea406f597d5d18c
     name: coreutils-common
-    evr: 9.11-1.hum1
-    sourcerpm: coreutils-9.11-1.hum1.src.rpm
+    evr: 9.11-2.hum1
+    sourcerpm: coreutils-9.11-2.hum1.src.rpm
   - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/c/cpp-15.2.1-7.2.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
     size: 13567328
@@ -95,13 +95,13 @@ arches:
     name: gcc-c++
     evr: 15.2.1-7.2.hum1
     sourcerpm: gcc-15.2.1-7.2.hum1.src.rpm
-  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/g/glibc-devel-2.42-12.hum1.x86_64.rpm
+  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/g/glibc-devel-2.42-13.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
-    size: 624933
-    checksum: sha256:b5dbca010d699d833f1494472b7cb5792c1e623f2e38f936cbde59f8f0091d72
+    size: 625892
+    checksum: sha256:fa6bfba2c342ab2575dc0771b964c0dda3cdfeeba0c3a921788af552fb8c9dc0
     name: glibc-devel
-    evr: 2.42-12.hum1
-    sourcerpm: glibc-2.42-12.hum1.src.rpm
+    evr: 2.42-13.hum1
+    sourcerpm: glibc-2.42-13.hum1.src.rpm
   - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/g/gmp-6.3.0-5.1.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
     size: 333708
@@ -151,13 +151,13 @@ arches:
     name: krb5-libs
     evr: 1.22.2-7.hum1
     sourcerpm: krb5-1.22.2-7.hum1.src.rpm
-  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libblkid-2.42-7.1.hum1.x86_64.rpm
+  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libblkid-2.42.1-4.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
-    size: 135635
-    checksum: sha256:02af99c3a6e14c8f2a2316dacd36a79f6baf4abac7dd552637f12d3e6d0570c4
+    size: 136001
+    checksum: sha256:1721e093e05a9c4d997b2cde06d2acb55b8daffea67c8df79d541909e28ab786
     name: libblkid
-    evr: 2.42-7.1.hum1
-    sourcerpm: util-linux-2.42-7.1.hum1.src.rpm
+    evr: 2.42.1-4.hum1
+    sourcerpm: util-linux-2.42.1-4.hum1.src.rpm
   - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libbrotli-1.2.0-3.1.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
     size: 364669
@@ -179,13 +179,13 @@ arches:
     name: libcom_err
     evr: 1.47.4-1.1.hum1
     sourcerpm: e2fsprogs-1.47.4-1.1.hum1.src.rpm
-  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libcurl-8.20.0-0.1.hum1.x86_64.rpm
+  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libcurl-8.20.0-2.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
-    size: 464817
-    checksum: sha256:708b0a0d66568ae5f4fcaf3d00a58ab26aedd80723de3f3dfc7df1ad2030ccc4
+    size: 464163
+    checksum: sha256:95c31efc6df24454f6a629ed2c55ea96f12d3234602071be8e813c47fae1e15d
     name: libcurl
-    evr: 8.20.0-0.1.hum1
-    sourcerpm: curl-8.20.0-0.1.hum1.src.rpm
+    evr: 8.20.0-2.hum1
+    sourcerpm: curl-8.20.0-2.hum1.src.rpm
   - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libevent-2.1.12-17.1.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
     size: 273550
@@ -193,13 +193,13 @@ arches:
     name: libevent
     evr: 2.1.12-17.1.hum1
     sourcerpm: libevent-2.1.12-17.1.hum1.src.rpm
-  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libfdisk-2.42-7.1.hum1.x86_64.rpm
+  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libfdisk-2.42.1-4.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
-    size: 171544
-    checksum: sha256:17c26a8743d54d2268aa4b094edbf5570db2d004360bdc45c13494bafe686791
+    size: 171636
+    checksum: sha256:a3a414c64c52fe232dadfc880d782ed227705042d6f8dca2e6be505b29922ef0
     name: libfdisk
-    evr: 2.42-7.1.hum1
-    sourcerpm: util-linux-2.42-7.1.hum1.src.rpm
+    evr: 2.42.1-4.hum1
+    sourcerpm: util-linux-2.42.1-4.hum1.src.rpm
   - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libfido2-1.17.0-2.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
     size: 109813
@@ -221,20 +221,20 @@ arches:
     name: libidn2
     evr: 2.3.8-3.1.hum1
     sourcerpm: libidn2-2.3.8-3.1.hum1.src.rpm
-  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/liblastlog2-2.42-7.1.hum1.x86_64.rpm
+  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/liblastlog2-2.42.1-4.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
-    size: 29932
-    checksum: sha256:2764b3a096d017c7855fca727a9beb60196ad8f64edd03e0e91eb827e697f678
+    size: 30283
+    checksum: sha256:fac36636dbe7c628da3ab0b4fd01c600ac3aadd8c2d440440d78448f7cfc7065
     name: liblastlog2
-    evr: 2.42-7.1.hum1
-    sourcerpm: util-linux-2.42-7.1.hum1.src.rpm
-  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libmount-2.42-7.1.hum1.x86_64.rpm
+    evr: 2.42.1-4.hum1
+    sourcerpm: util-linux-2.42.1-4.hum1.src.rpm
+  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libmount-2.42.1-4.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
-    size: 176601
-    checksum: sha256:48fc9e9828a79c648f8ac0a9a59f71248c207a1105aba45b017b90d1452547ec
+    size: 176970
+    checksum: sha256:48fb7d2a95a9e4e7691dccd0a3ec022c89a1266fe70eb03548caaaad09a82f1c
     name: libmount
-    evr: 2.42-7.1.hum1
-    sourcerpm: util-linux-2.42-7.1.hum1.src.rpm
+    evr: 2.42.1-4.hum1
+    sourcerpm: util-linux-2.42.1-4.hum1.src.rpm
   - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libmpc-1.4.1-1.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
     size: 81975
@@ -242,13 +242,13 @@ arches:
     name: libmpc
     evr: 1.4.1-1.hum1
     sourcerpm: libmpc-1.4.1-1.hum1.src.rpm
-  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libnghttp2-1.69.0-1.hum1.x86_64.rpm
+  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libnghttp2-1.69.0-2.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
-    size: 80980
-    checksum: sha256:ad5316f2de492c2e80a938214a41d668131d16428c584e4c709c3d9bc32d35b0
+    size: 81085
+    checksum: sha256:d9b5ac1069381886ea1d39c21a53ca50cf3435583fec40e3148eb36cc64fbb72
     name: libnghttp2
-    evr: 1.69.0-1.hum1
-    sourcerpm: nghttp2-1.69.0-1.hum1.src.rpm
+    evr: 1.69.0-2.hum1
+    sourcerpm: nghttp2-1.69.0-2.hum1.src.rpm
   - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libnghttp3-1.15.0-1.1.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
     size: 78361
@@ -270,13 +270,13 @@ arches:
     name: libpsl
     evr: 0.21.5-7.1.hum1
     sourcerpm: libpsl-0.21.5-7.1.hum1.src.rpm
-  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libsmartcols-2.42-7.1.hum1.x86_64.rpm
+  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libsmartcols-2.42.1-4.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
-    size: 92863
-    checksum: sha256:92c055dc08c06ebb283545cd7a15c30ea8cb2aeb4cd6bd5789abb96a77345049
+    size: 92798
+    checksum: sha256:f097c0aa4d8a6e02ba39c3f59ffd7a9900f23dc25a1c05e762027840c4380187
     name: libsmartcols
-    evr: 2.42-7.1.hum1
-    sourcerpm: util-linux-2.42-7.1.hum1.src.rpm
+    evr: 2.42.1-4.hum1
+    sourcerpm: util-linux-2.42.1-4.hum1.src.rpm
   - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/l/libssh-0.12.0-1.1.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
     size: 290622
@@ -410,26 +410,26 @@ arches:
     name: publicsuffix-list-dafsa
     evr: 20260116-1.1.hum1
     sourcerpm: publicsuffix-list-20260116-1.1.hum1.src.rpm
-  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/p/python3-devel-3.14.4-2.hum1.x86_64.rpm
+  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/p/python3-devel-3.14.5-1.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
-    size: 474045
-    checksum: sha256:e33cd65ec60ddc9bda3e1584671989e0951fe0902f1c21b6c5499a3a904ea17d
+    size: 474158
+    checksum: sha256:e7478f844b312be1370b5bc329b9767d26672c9497d60518583092147a9f01b7
     name: python3-devel
-    evr: 3.14.4-2.hum1
-    sourcerpm: python3.14-3.14.4-2.hum1.src.rpm
-  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/u/util-linux-2.42-7.1.hum1.x86_64.rpm
+    evr: 3.14.5-1.hum1
+    sourcerpm: python3.14-3.14.5-1.hum1.src.rpm
+  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/u/util-linux-2.42.1-4.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
-    size: 1372396
-    checksum: sha256:9ccf068ea0c673bfc4816abf91678fe4178b00d8f21a110d12935c416fbdc9ee
+    size: 1365905
+    checksum: sha256:0d6bd7e09bb06ae0516adec35d9ae31d1ed7f635f95f44c84ccd57b27150bb8a
     name: util-linux
-    evr: 2.42-7.1.hum1
-    sourcerpm: util-linux-2.42-7.1.hum1.src.rpm
-  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/u/util-linux-core-2.42-7.1.hum1.x86_64.rpm
+    evr: 2.42.1-4.hum1
+    sourcerpm: util-linux-2.42.1-4.hum1.src.rpm
+  - url: https://koji-s3-cache.hummingbird-project.io/packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/Packages/u/util-linux-core-2.42.1-4.hum1.x86_64.rpm
     repoid: public-hummingbird-x86_64-rpms
-    size: 607410
-    checksum: sha256:15caec90e009823591cd47a3eaf237664b4742a1f616a0702d1f8adacbe5e23e
+    size: 605172
+    checksum: sha256:cc1cd62c64d5f4f74762403b82407ed538fff29915a1865feddca62d094cb542
     name: util-linux-core
-    evr: 2.42-7.1.hum1
-    sourcerpm: util-linux-2.42-7.1.hum1.src.rpm
+    evr: 2.42.1-4.hum1
+    sourcerpm: util-linux-2.42.1-4.hum1.src.rpm
   source: []
   module_metadata: []


### PR DESCRIPTION
## Summary
- Regenerated `hermetic/rpms.lock.yaml` to match current Hummingbird repo package versions
- Fixes hermetic build failure caused by stale lockfile with version mismatches (glibc-devel 2.42-12→13, python3-devel 3.14.4→3.14.5, util-linux 2.42→2.42.1, etc.)
- Prefetched RPMs now resolve correctly against the current base image