### PR TITLE
fix(deps): upgrade urllib3 to 2.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -207,9 +207,9 @@ six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via python-dateutil
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via botocore
 watchtower==3.4.0 \
     --hash=sha256:5eac65cbf2a7350bb43c3518485230a6135ed7dec7ccb88468828d68ab9fea26 \


### PR DESCRIPTION
## Summary

Upgrades `urllib3` from 2.6.3 to 2.7.0 to fix two security vulnerabilities:

- **CVE-2026-44432**: Denial of Service due to excessive HTTP response decompression — urllib3 could decompress the entire response instead of the requested portion, causing high CPU/memory usage
- **CVE-2026-44431**: Information disclosure via cross-origin redirects forwarding sensitive headers

Both vulnerabilities are fixed in urllib3 2.7.0.

**RHCLOUD-47903** / **RHCLOUD-47923**

### Changes

- `requirements.txt`: bumped `urllib3` from 2.6.3 to 2.7.0 with updated hashes

### Notes

- `urllib3` is a transitive dependency via `botocore` (AWS SDK)
- This is a patch-level lockfile update with no API changes
- Verified hashes match the [Mintmaker urllib3-2.x branch](https://github.com/RedHatInsights/insights-storage-broker/tree/konflux/mintmaker/master/urllib3-2.x)

## Test plan

- [ ] CI passes (hermetic build, security scans)
- [ ] No functional changes — transitive dependency update only